### PR TITLE
Fix invalid data after reboot

### DIFF
--- a/aggregatebatteries.py
+++ b/aggregatebatteries.py
@@ -454,7 +454,8 @@ class DbusAggBatService(object):
                     else:
                         Current_VE -= self._dbusMon.dbusmon.get_value(self._smartShunt, '/Dc/0/Current')
                         
-                Current = Current_VE                                                                                # BMS current overwritten only if no exception raised
+                if Current_VE is not None:
+	            Current = Current_VE                                                                            # BMS current overwritten only if no exception raised
                 Power = Voltage * Current_VE                                                                        # calculate own power (not read from BMS)        
             
             except Exception:


### PR DESCRIPTION
@Dr-Gigavolt: I saw in the last days the same issues as #15 The reason of trouble is that for instance the multi plus was found, but the first whole dataset wasn't published on the DBus after a reboot and results in an exception e.g. when asking for the DC current ([here](https://github.com/Dr-Gigavolt/dbus-aggregate-batteries/blob/22edc8e4652d9b1824edead0a6f86fb5d3f8448a/aggregatebatteries.py#L447)).

In this edge case an exception was raised later than expected (because we have no MPPT or SHUNT otherwise it will raise earlier)

