### PR TITLE
fix: remove trailing colon from version numbers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # download and install the latest version of the script
-latest_release=$(curl -s https://api.github.com/repos/Dr-Gigavolt/dbus-aggregate-batteries/releases/latest | grep "tag_name" | cut -d : -f 2,3 | tr -d "\ " | tr -d \" | tr -d \,)
+latest_release=$(curl -s https://api.github.com/repos/Dr-Gigavolt/dbus-aggregate-batteries/releases/latest | grep "tag_name" | cut -d : -f 2,3 | tr -d "\ " | tr -d \" | tr -d \, | sed 's/:$//')
 
 echo "Downloading latest release: $latest_release"
 


### PR DESCRIPTION
Problem: When a version number ended with a colon (e.g., "latest release: 3.4-beta:"), it created invalid download URLs like "...tags/3.4-beta:.zip", resulting in 404 errors during download and installation attempts.

Solution: Added logic to detect and remove trailing colons from version numbers, ensuring proper URL formation and successful downloads.

While the script worked without issues on one Cerbo device, it failed on two others that had detected the trailing colon. This fix now addresses the issue across all devices.