### PR TITLE
added "settings:" before KEEP_MAX_CVL

### DIFF
--- a/aggregatebatteries.py
+++ b/aggregatebatteries.py
@@ -889,7 +889,7 @@ class DbusAggBatService(object):
 
         # find max. charge voltage (if needed)
         if not settings.OWN_CHARGE_PARAMETERS:
-            if KEEP_MAX_CVL and ("Float" in ChargeMode_list):
+            if settings.KEEP_MAX_CVL and ("Float" in ChargeMode_list):
                 MaxChargeVoltage = self._fn._max(MaxChargeVoltage_list)
                     
             else:


### PR DESCRIPTION
Otherwise the aggregate batteries crashes at the start, when the program goes down the path where the variable is read.