### PR TITLE
Check if charge mode contains "Float", not is equal to

### DIFF
--- a/aggregatebatteries.py
+++ b/aggregatebatteries.py
@@ -889,7 +889,7 @@ class DbusAggBatService(object):
 
         # find max. charge voltage (if needed)
         if not settings.OWN_CHARGE_PARAMETERS:
-            if settings.KEEP_MAX_CVL and ("Float" in ChargeMode_list):
+            if settings.KEEP_MAX_CVL and ("Float" in s for s in ChargeMode_list):
                 MaxChargeVoltage = self._fn._max(MaxChargeVoltage_list)
                     
             else:


### PR DESCRIPTION
Currently, the logic checks if the string is equal to "Float" which on the latest Serial battery driver it is not. eg. "Float │ Linear Mode"