### PR TITLE
Correct repo and redo the lost fix removed with commit 39ed0ebcf659b26daa10e8c4cce974a84f8f1f26 from 07.07.2025

### DIFF
--- a/aggregatebatteries.py
+++ b/aggregatebatteries.py
@@ -889,7 +889,7 @@ class DbusAggBatService(object):
 
         # find max. charge voltage (if needed)
         if not settings.OWN_CHARGE_PARAMETERS:
-            if settings.KEEP_MAX_CVL and ("Float" in s for s in ChargeMode_list):
+            if settings.KEEP_MAX_CVL and any("Float" in item for item in ChargeMode_list):
                 MaxChargeVoltage = self._fn._max(MaxChargeVoltage_list)
                     
             else:


### PR DESCRIPTION
The last pull request done a few minutes ago misses the any().

ChatGpt explains it like this: 

The difference lies in how the expressions are evaluated:

`if settings.KEEP_MAX_CVL and any("Float" in item for item in ChargeMode_list):`

This checks if settings.KEEP_MAX_CVL is True and if any item in ChargeMode_list contains the substring "Float". The any() function returns True if at least one of the conditions is True.

`if settings.KEEP_MAX_CVL and ("Float" in item for item in ChargeMode_list):`

This evaluates ("Float" in item for item in ChargeMode_list) as a generator expression, which creates an iterable but does not evaluate it. The condition will always be truthy because the generator itself is a valid object, regardless of whether "Float" is found in any item.

In summary, the first checks for actual matches, while the second does not evaluate the condition properly.