### PR TITLE
Fix AttributeError on _settings during startup race condition

### DIFF
--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -80,6 +80,7 @@ class DbusAggBatService(object):
         # the number of SmartShunts at the beginning of _smartShunt_list that are in the
         # battery service (dc_load are listed behind)
         self._num_battery_shunts = 0
+        self._settings = None
         self._searchTrials = 1
         self._readTrials = 1
         self._MaxChargeVoltage_old = 0


### PR DESCRIPTION
## Bug

On systems where `com.victronenergy.settings` takes longer to register on D-Bus (e.g. during boot on a Cerbo GX with many services), `_find_settings()` runs before the settings service is available. When this happens:

1. The `for` loop in `_find_settings()` (line 308) iterates `self._dbusConn.list_names()` but does **not** find `com.victronenergy.settings`
2. `self._settings` is **never assigned** (it is only set inside the loop body at line 310)
3. The check on line 324 (`if self._settings is not None:`) raises:

```
AttributeError: 'DbusAggBatService' object has no attribute '_settings'
```

This is a race condition — `_find_settings()` is designed to retry (via `_searchTrials`), but it cannot retry because the `AttributeError` on line 324 is not caught by the existing `try/except` block (which only wraps the D-Bus enumeration on lines 307–322).

## Impact

After the `AttributeError`, the aggregate service appears to run (runit keeps the process alive) but **never progresses** to finding batteries or publishing aggregate values. D-Bus queries return empty values (`[]`) for the remainder of the session, even after individual batteries come online. A manual `svc -t` restart is required to recover.

## Fix

Initialize `self._settings = None` in `__init__()`, consistent with how other attributes like `self._multi` (line 67) and `self._dbusMon` (line 78) are initialized.

This allows the existing retry logic to work as intended — when `com.victronenergy.settings` is not found on the first trial, `_find_settings()` correctly falls through to the `elif self._searchTrials < settings.SEARCH_TRIALS:` branch and retries until the settings service appears.

## Testing

Tested on Venus OS (Cerbo GX, firmware v3.x) with two BLE batteries:

- **Before fix**: On reboot, aggregate service logged `AttributeError` and returned empty D-Bus values indefinitely
- **After fix**: On reboot, `_find_settings()` retries normally, finds settings once available, proceeds to discover batteries, and publishes correct aggregate values — zero `AttributeError` occurrences in the log