### PR TITLE
fix: use dbus.SystemBus() singleton to prevent D-Bus connection leaks

### DIFF
--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -43,18 +43,9 @@ from vedbus import VeDbusService  # noqa: E402
 VERSION = "4.0.20260210-beta"
 
 
-class SystemBus(dbus.bus.BusConnection):
-    def __new__(cls):
-        return dbus.bus.BusConnection.__new__(cls, dbus.bus.BusConnection.TYPE_SYSTEM)
-
-
-class SessionBus(dbus.bus.BusConnection):
-    def __new__(cls):
-        return dbus.bus.BusConnection.__new__(cls, dbus.bus.BusConnection.TYPE_SESSION)
-
-
-def get_bus() -> dbus.bus.BusConnection:
-    return SessionBus() if "DBUS_SESSION_BUS_ADDRESS" in os.environ else SystemBus()
+def get_bus():
+    """Return the shared system bus connection (singleton provided by dbus-python)."""
+    return dbus.SessionBus() if "DBUS_SESSION_BUS_ADDRESS" in os.environ else dbus.SystemBus()
 
 
 class DbusAggBatService(object):


### PR DESCRIPTION
## Summary

- Replace custom `SystemBus(dbus.bus.BusConnection)` / `SessionBus(dbus.bus.BusConnection)` classes with standard `dbus.SystemBus()` / `dbus.SessionBus()` calls
- `dbus.bus.BusConnection` creates a **new** connection on every instantiation. When `DBusGMainLoop(set_as_default=True)` is active, these connections are pinned in memory by C-level GLib watch/timeout references that Python's GC cannot reach, eventually exhausting the per-UID D-Bus connection limit (`org.freedesktop.DBus.Error.LimitsExceeded`)
- `dbus.SystemBus()` / `dbus.SessionBus()` return an internally-cached singleton, ensuring only one connection per process

## Test plan

- [x] Verified service starts and registers on D-Bus
- [x] Confirmed stable file descriptor counts after restart

Made with [Cursor](https://cursor.com)