### PR TITLE
Configure unit tests and add AGGREGATE_CHARGE_MODE setting

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,4 +1,4 @@
-name: "Black lint and flake8 checks"
+name: "Black lint and flake8 checks, and tests"
 
 on:
   push:
@@ -36,3 +36,24 @@ jobs:
 
     - name: Perform flake8 lint check
       uses: py-actions/flake8@v2
+
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python environment
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+
+    - name: Run tests
+      run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+__pycache__/
+.DS_Store
 config.ini

--- a/config.default.ini
+++ b/config.default.ini
@@ -261,6 +261,38 @@ CELL_DISCHARGE_LIMITED_CURRENT = 0, 0.05, 1
 
 
 ; --------- if OWN_CHARGE_PARAMETERS = False ---------
+; If AGGREGATE_CHARGE_MODE is False, KEEP_MAX_CVL setting controls the CVL.
+; If AGGREGATE_CHARGE_MODE is True, KEEP_MAX_CVL is ignored, and the charge mode is aggregated across all batteries
+; in a stateful manner. This, compared to what's achievable with KEEP_MAX_CVL=True, allows safer more fine-tuned
+; control over CVL:
+;
+; After all batteries go out of Float and Float Transition modes: set BULK_OR_ABSORPTION mode in the aggregator and
+; keep it that way until the last battery goes out of Bulk or Absorption mode.
+; In BULK_OR_ABSORPTION aggregator mode, use min CVL among all batteries excluding batteries in Float or
+; Float Transition modes.
+;
+; After the last battery goes to Float Transition mode and all other batteries are in Float mode: set Float Transition
+; mode in the aggregator.
+; In Float Transition aggregator mode, use max CVL among all batteries with Float Transition mode, limited by min CVL
+; among all batteries in Bulk or Absorption modes.
+;
+; After all batteries are in Float mode and there's no batteries in Float Transition mode: set Float mode in the
+; aggregator.
+; In Float aggregator mode, use min CVL among all batteries.
+;
+; Compared to KEEP_MAX_CVL=True, this ensures the following scenarios are handled correctly:
+; - After all batteries are in bulk or absorption mode, the aggregator waits until the last battery goes to float
+;   before lowering the CVL (KEEP_MAX_CVL also handles this correctly).
+; - When a single battery lowers CVL to avoid cell overvoltage, the lower CVL is respected no matter whether other
+;   batteries are in bulk or float mode (KEEP_MAX_CVL doesn't handle this correctly when there's one or more batteries
+;   in float mode).
+; - After all batteries are charged and the last battery switches to Float Transition mode, CVL follows the transition
+;   curve without a sudden change to a lower CVL (KEEP_MAX_CVL also handles this correctly).
+; - When all batteries are in float mode, and a single battery switches to bulk mode, the aggregator stays in float
+;   mode until *all* batteries request bulk mode. This makes sure dbus-serialbattery properly runs the required logic
+;   for cell balancing and SOC reset for all batteries (KEEP_MAX_CVL doesn't handle this correctly).
+AGGREGATE_CHARGE_MODE = False
+
 ; If False, the transmitted CVL is always the minimum of all batteries
 ; If True, the transmitted CVL is the maximum of all batteries until all are in float,
 ; than the minimum of all is taken. Attention: By using this function you rely on the functionality

--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -22,6 +22,7 @@ import platform
 import dbus
 import re
 import settings
+from enum import Enum
 from functions import Functions
 
 # for UTC time stamps for logging
@@ -41,6 +42,12 @@ sys.path.insert(1, os.path.join(os.path.dirname(__file__), "ext"))
 from vedbus import VeDbusService, VeDbusItemImport  # noqa: E402
 
 VERSION = "4.0.20260217-beta"
+
+
+class AggregatedChargeMode(Enum):
+    BULK_OR_ABSORPTION = 1
+    FLOAT_TRANSITION = 2
+    FLOAT = 3
 
 
 def get_bus():
@@ -101,6 +108,7 @@ class DbusAggBatService(object):
         self._dynamicCVL = False
         # last timestamp then the log was printed
         self._logLastPrintTimeStamp = 0
+        self._aggregated_charge_mode: AggregatedChargeMode = AggregatedChargeMode.FLOAT
 
         self.SETTINGS_PATH_SHORT = "Devices/aggregatebatteries/CustomName"  # without /Settings/ prefix for AddSetting
         self.SETTINGS_PATH = "/Settings/" + self.SETTINGS_PATH_SHORT  # with /Settings/ prefix for VeDbusItemImport
@@ -1040,7 +1048,11 @@ class DbusAggBatService(object):
 
         # find max. charge voltage (if needed)
         if not settings.OWN_CHARGE_PARAMETERS:
-            if settings.KEEP_MAX_CVL and any("Float" in item for item in ChargeMode_list):
+            if settings.AGGREGATE_CHARGE_MODE:
+                self._update_aggregated_charge_mode(ChargeMode_list)
+                MaxChargeVoltage = self._get_cvl_with_aggregated_charge_mode(MaxChargeVoltage_list, ChargeMode_list)
+
+            elif settings.KEEP_MAX_CVL and any("Float" in item for item in ChargeMode_list):
                 MaxChargeVoltage = self._fn._max(MaxChargeVoltage_list)
 
             else:
@@ -1451,6 +1463,48 @@ class DbusAggBatService(object):
             )
 
         return True
+
+    def _update_aggregated_charge_mode(self, ChargeMode_list: list):
+        if not any("Float" in mode for mode in ChargeMode_list):
+            # All batteries are in Bulk or Absorbtion mode.
+            self._set_aggregated_charge_mode(AggregatedChargeMode.BULK_OR_ABSORPTION)
+        elif any("Float Transition" in mode for mode in ChargeMode_list) and all("Float" in mode for mode in ChargeMode_list):
+            # The last battery went to Float Transition mode and all other batteries are in Float mode.
+            self._set_aggregated_charge_mode(AggregatedChargeMode.FLOAT_TRANSITION)
+        elif all("Float" in mode for mode in ChargeMode_list):
+            # All batteries are in Float mode and there's no batteries in Float Transition mode.
+            self._set_aggregated_charge_mode(AggregatedChargeMode.FLOAT)
+        else:
+            # Any other case leaves the mode unchanged.
+            pass
+
+    def _set_aggregated_charge_mode(self, mode: AggregatedChargeMode):
+        if self._aggregated_charge_mode != mode:
+            self._aggregated_charge_mode = mode
+            logging.info(f"Switching the aggregated charge mode to {mode.name}")
+
+    def _get_cvl_with_aggregated_charge_mode(self, MaxChargeVoltage_list: list, ChargeMode_list: list):
+        BulkOrAbsorptionCVLs = []
+        FloatTransitionCVLs = []
+        FloatCVLs = []
+        for voltage, mode in zip(MaxChargeVoltage_list, ChargeMode_list):
+            if mode.startswith("Float Transition"):
+                FloatTransitionCVLs.append(voltage)
+            elif mode.startswith("Float"):
+                FloatCVLs.append(voltage)
+            else:
+                BulkOrAbsorptionCVLs.append(voltage)
+
+        match self._aggregated_charge_mode:
+            case AggregatedChargeMode.BULK_OR_ABSORPTION:
+                # Ignore float voltages to ensure all batteries in Bulk or Absorption modes can finish charging.
+                return self._fn._min(BulkOrAbsorptionCVLs)
+            case AggregatedChargeMode.FLOAT_TRANSITION:
+                # Use max CVL among all batteries in Float Transition modes, limited for safety by min CVL among all batteries in Bulk or Absorption modes.
+                cap = self._fn._min(BulkOrAbsorptionCVLs) if BulkOrAbsorptionCVLs else float("inf")
+                return self._fn._min([self._fn._max(FloatTransitionCVLs), cap])
+            case AggregatedChargeMode.FLOAT:
+                return self._fn._min(MaxChargeVoltage_list)
 
 
 # ################

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = -vv
+log_cli = True
+log_cli_level = INFO
+pythonpath = .
+testpaths = tests

--- a/settings.py
+++ b/settings.py
@@ -265,6 +265,7 @@ if not CELL_DISCHARGE_LIMITED_CURRENT or len(CELL_DISCHARGE_LIMITED_CURRENT) < 2
 
 # --------- if OWN_CHARGE_PARAMETERS = False ---------
 KEEP_MAX_CVL: bool = get_bool_from_config("DEFAULT", "KEEP_MAX_CVL")
+AGGREGATE_CHARGE_MODE: bool = get_bool_from_config("DEFAULT", "AGGREGATE_CHARGE_MODE")
 SEND_CELL_VOLTAGES: int = get_int_from_config("DEFAULT", "SEND_CELL_VOLTAGES")
 LOG_PERIOD: int = get_int_from_config("DEFAULT", "LOG_PERIOD")
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,5 @@
+Add unit tests here.
+
+Run them with `pytest` (you might need to install `pytest` package first).
+
+The directory structure matches the tested code: one *test* file per one *tested* file, and the names of the test files are `test_<name_of_tested_file>.py`

--- a/tests/test_dbus-aggregate-batteries.py
+++ b/tests/test_dbus-aggregate-batteries.py
@@ -1,0 +1,236 @@
+import importlib.util
+import sys
+from functions import Functions
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Mock external dependencies before importing the module under test
+# ---------------------------------------------------------------------------
+
+
+class _MockBusConnection:
+    """Stand-in for dbus.bus.BusConnection enabling class inheritance."""
+
+    TYPE_SYSTEM = 0
+    TYPE_SESSION = 1
+
+
+_mock_dbus = MagicMock()
+_mock_dbus.bus.BusConnection = _MockBusConnection
+
+for _name, _mock in {
+    "gi": MagicMock(),
+    "gi.repository": MagicMock(),
+    "dbus": _mock_dbus,
+    "dbus.bus": _mock_dbus.bus,
+    "settings": MagicMock(),
+    "dbusmon": MagicMock(),
+    "vedirect_shunt_monitor": MagicMock(),
+    "vedbus": MagicMock(),
+}.items():
+    sys.modules[_name] = _mock
+
+# ---------------------------------------------------------------------------
+# Import the module under test (filename contains hyphens)
+# ---------------------------------------------------------------------------
+
+_spec = importlib.util.spec_from_file_location("dbus_aggregate_batteries", "dbus-aggregate-batteries.py")
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+AggregatedChargeMode = _module.AggregatedChargeMode
+DbusAggBatService = _module.DbusAggBatService
+
+_ALL_MODES = list(AggregatedChargeMode)
+_ALL_MODE_NAMES = [m.name for m in AggregatedChargeMode]
+
+# ---------------------------------------------------------------------------
+# Helpers and fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def service():
+    """Lightweight DbusAggBatService that bypasses __init__."""
+    svc = object.__new__(DbusAggBatService)
+    svc._aggregated_charge_mode = AggregatedChargeMode.FLOAT
+    svc._fn = Functions()
+    return svc
+
+
+# ===========================================================================
+
+
+class TestUpdateAggregatedChargeMode:
+
+    @pytest.mark.parametrize(
+        "charge_modes, expected",
+        [
+            (["Bulk"], AggregatedChargeMode.BULK_OR_ABSORPTION),
+            (["Bulk", "Absorption"], AggregatedChargeMode.BULK_OR_ABSORPTION),
+            (["Absorption", "Bulk", "Absorption"], AggregatedChargeMode.BULK_OR_ABSORPTION),
+            (["Float Transition"], AggregatedChargeMode.FLOAT_TRANSITION),
+            (["Float", "Float Transition", "Float"], AggregatedChargeMode.FLOAT_TRANSITION),
+            (["Float Transition", "Float Transition"], AggregatedChargeMode.FLOAT_TRANSITION),
+            (["Float"], AggregatedChargeMode.FLOAT),
+            (["Float", "Float"], AggregatedChargeMode.FLOAT),
+        ],
+        ids=[
+            "single_bulk",
+            "bulk_and_absorption",
+            "three_non_float",
+            "single_float_transition",
+            "float_transition_among_floats",
+            "all_float_transition",
+            "single_float",
+            "all_float",
+        ],
+    )
+    @pytest.mark.parametrize("initial_mode", _ALL_MODES, ids=_ALL_MODE_NAMES)
+    def test_deterministic_transitions(self, service, initial_mode, charge_modes, expected):
+        service._aggregated_charge_mode = initial_mode
+        service._update_aggregated_charge_mode(charge_modes)
+        assert service._aggregated_charge_mode == expected
+
+    @pytest.mark.parametrize(
+        "charge_modes",
+        [
+            ["Bulk", "Float"],
+            ["Float", "Absorption"],
+            ["Bulk", "Float Transition"],
+            ["Absorption", "Float Transition", "Bulk"],
+            ["Bulk", "Float", "Float Transition"],
+        ],
+        ids=[
+            "bulk_with_float",
+            "float_with_absorption",
+            "bulk_with_float_transition",
+            "three_mixed_types",
+            "all_category_types_mixed",
+        ],
+    )
+    @pytest.mark.parametrize("initial_mode", _ALL_MODES, ids=_ALL_MODE_NAMES)
+    def test_mixed_modes_leave_state_unchanged(self, service, initial_mode, charge_modes):
+        service._aggregated_charge_mode = initial_mode
+        service._update_aggregated_charge_mode(charge_modes)
+        assert service._aggregated_charge_mode == initial_mode
+
+
+class TestGetCvlWithAggregatedChargeMode:
+
+    @pytest.mark.parametrize(
+        "voltages, modes, expected",
+        [
+            ([56.0, 55.5], ["Bulk", "Absorption"], 55.5),
+            ([56.0, 54.0], ["Bulk", "Float"], 56.0),
+            ([55.0, 56.0, 54.0], ["Bulk", "Bulk", "Float"], 55.0),
+        ],
+        ids=[
+            "all_bulk_returns_min",
+            "float_voltage_ignored",
+            "reduced_bulk_voltage_respected",
+        ],
+    )
+    def test_bulk_or_absorption_mode(self, service, voltages, modes, expected):
+        service._aggregated_charge_mode = AggregatedChargeMode.BULK_OR_ABSORPTION
+        assert service._get_cvl_with_aggregated_charge_mode(voltages, modes) == expected
+
+    @pytest.mark.parametrize(
+        "voltages, modes, expected",
+        [
+            ([55.0, 55.5], ["Float Transition", "Float Transition"], 55.5),
+            ([56.0, 57.0, 55.0], ["Float Transition", "Bulk", "Bulk"], 55.0),
+            ([56.0, 54.0], ["Float Transition", "Float"], 56.0),
+            ([55.0, 57.0, 55.2], ["Float Transition", "Float Transition", "Bulk"], 55.2),
+        ],
+        ids=[
+            "max_of_transitions",
+            "capped_by_bulk",
+            "uncapped_when_no_bulk",
+            "multiple_transitions_capped_by_bulk",
+        ],
+    )
+    def test_float_transition_mode(self, service, voltages, modes, expected):
+        service._aggregated_charge_mode = AggregatedChargeMode.FLOAT_TRANSITION
+        assert service._get_cvl_with_aggregated_charge_mode(voltages, modes) == expected
+
+    @pytest.mark.parametrize(
+        "voltages, modes, expected",
+        [
+            ([54.0, 55.0], ["Float", "Float"], 54.0),
+            ([56.0, 54.0], ["Bulk", "Float"], 54.0),
+            ([56.0, 55.0, 54.0], ["Bulk", "Float Transition", "Float"], 54.0),
+        ],
+        ids=[
+            "all_float_returns_min",
+            "mixed_returns_global_min",
+            "three_types_returns_global_min",
+        ],
+    )
+    def test_float_mode(self, service, voltages, modes, expected):
+        service._aggregated_charge_mode = AggregatedChargeMode.FLOAT
+        assert service._get_cvl_with_aggregated_charge_mode(voltages, modes) == expected
+
+
+class TestAggregatedChargeModeStatefulScenarios:
+    """Multi-step tests verifying stateful CVL behavior."""
+
+    def _step(self, service, charge_modes, voltages):
+        """Simulate one update cycle: advance mode, then return the CVL."""
+        service._update_aggregated_charge_mode(charge_modes)
+        return service._get_cvl_with_aggregated_charge_mode(voltages, charge_modes)
+
+    def test_waits_for_last_battery_to_leave_bulk_before_lowering_cvl(self, service):
+        service._aggregated_charge_mode = AggregatedChargeMode.FLOAT
+
+        # Both batteries start in Bulk
+        cvl = self._step(service, ["Bulk", "Bulk"], [55.5, 56.0])
+        assert service._aggregated_charge_mode == AggregatedChargeMode.BULK_OR_ABSORPTION
+        assert cvl == 55.5
+
+        # First battery reaches Float; aggregator stays in BULK_OR_ABSORPTION
+        cvl = self._step(service, ["Float", "Bulk"], [54.0, 56.0])
+        assert service._aggregated_charge_mode == AggregatedChargeMode.BULK_OR_ABSORPTION
+        assert cvl == 56.0
+
+        # Second battery enters Float Transition
+        cvl = self._step(service, ["Float", "Float Transition"], [54.0, 55.5])
+        assert service._aggregated_charge_mode == AggregatedChargeMode.FLOAT_TRANSITION
+        assert cvl == 55.5
+
+        # Both batteries in Float
+        cvl = self._step(service, ["Float", "Float"], [54.0, 54.0])
+        assert service._aggregated_charge_mode == AggregatedChargeMode.FLOAT
+        assert cvl == 54.0
+
+    def test_reduced_cvl_respected_during_cell_overvoltage_protection(self, service):
+        """A battery in Bulk that lowers CVL to prevent cell overvoltage is
+        respected even while another battery is in Float."""
+        service._aggregated_charge_mode = AggregatedChargeMode.BULK_OR_ABSORPTION
+
+        cvl = self._step(service, ["Bulk", "Bulk", "Float"], [55.0, 56.0, 54.0])
+
+        assert cvl == 55.0
+
+    def test_single_battery_bulk_from_float_keeps_float_until_all_request_bulk(self, service):
+        """When all batteries are in Float and one switches to Bulk, the
+        aggregator stays in Float so that dbus-serialbattery can finish
+        balancing and SOC reset for every battery."""
+        service._aggregated_charge_mode = AggregatedChargeMode.FLOAT
+
+        # One battery switches to Bulk; aggregator stays in Float
+        cvl = self._step(service, ["Float", "Bulk", "Float"], [54.0, 56.0, 54.0])
+        assert service._aggregated_charge_mode == AggregatedChargeMode.FLOAT
+        assert cvl == 54.0
+
+        # Another battery switches to Bulk; aggregator stays in Float
+        cvl = self._step(service, ["Float", "Bulk", "Bulk"], [54.0, 56.0, 56.0])
+        assert service._aggregated_charge_mode == AggregatedChargeMode.FLOAT
+        assert cvl == 54.0
+
+        # All batteries leave Float - switches to BULK_OR_ABSORPTION
+        cvl = self._step(service, ["Bulk", "Bulk", "Bulk"], [55.5, 56.0, 56.0])
+        assert service._aggregated_charge_mode == AggregatedChargeMode.BULK_OR_ABSORPTION
+        assert cvl == 55.5


### PR DESCRIPTION
This setting allows the charge mode to be aggregated across all batteries in a stateful manner. It has an effect only if OWN_CHARGE_PARAMETERS = False.

Tested with unit tests and on a real system for a week.
I'm pretty sure this is strictly an improvement over the current default behavior, so if you'd like you can set AGGREGATE_CHARGE_MODE to True in config.default.ini after it's tested on more systems.

### Algorithm
This setting, compared to what's achievable with KEEP_MAX_CVL=True, allows safer more fine-tuned control over CVL:

After all batteries go out of Float and Float Transition modes: set BULK_OR_ABSORPTION mode in the aggregator and keep it that way until the last battery goes out of Bulk or Absorption mode. In BULK_OR_ABSORPTION aggregator mode, use min CVL among all batteries excluding batteries in Float or Float Transition modes.

After the last battery goes to Float Transition mode and all other batteries are in Float mode: set Float Transition mode in the aggregator. In Float Transition aggregator mode, use max CVL among all batteries with Float Transition mode, limited by min CVL among all batteries in Bulk or Absorption modes.

After all batteries are in Float mode and there's no batteries in Float Transition mode: set Float mode in the aggregator. In Float aggregator mode, use min CVL among all batteries.

### What this solves
Compared to KEEP_MAX_CVL=True, this ensures the following scenarios are handled correctly:
- After all batteries are in bulk or absorption mode, the aggregator waits until the last battery goes to float before lowering the CVL (KEEP_MAX_CVL also handles this correctly).
- When a single battery lowers CVL to avoid cell overvoltage, the lower CVL is respected no matter whether other batteries are in bulk or float mode (KEEP_MAX_CVL doesn't handle this correctly when there's one or more batteries in float mode).
- After all batteries are charged and the last battery switches to Float Transition mode, CVL follows the transition curve without a sudden change to a lower CVL (KEEP_MAX_CVL also handles this correctly).
- When all batteries are in float mode, and a single battery switches to bulk mode, the aggregator stays in float mode until *all* batteries request bulk mode. This makes sure dbus-serialbattery properly runs the required logic for cell balancing and SOC reset for all batteries (KEEP_MAX_CVL doesn't handle this correctly).