### PR TITLE
feat: support custom full-charge thresholds for own SoC reset

### DIFF
--- a/config.default.ini
+++ b/config.default.ini
@@ -168,6 +168,11 @@ ZERO_SOC = False
 MAX_CELL_VOLTAGE_SOC_FULL = 3.45
 MIN_CELL_VOLTAGE_SOC_EMPTY = 2.90
 
+; Optional full-charge thresholds if OWN_SOC = True and OWN_CHARGE_PARAMETERS = True
+; Set to 0 to disable one or both of these fallback signals
+OWN_SOC_FULL_VOLTAGE = 0
+OWN_SOC_FULL_CELL_MEDIAN_VOLTAGE = 0
+
 ; When the battery charge changes more than CHARGE_SAVE_PRECISION, the charge file is updated
 ; It is a trade-off between resolution and file access frequency. The value is relative
 ; The charge file is read on start of this program

--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -1225,7 +1225,13 @@ class DbusAggBatService(object):
                 self._lastBalancing = int((dt.now()).strftime("%j"))
                 _write_atomic(_STATE_FILE_BALANCING, "%s" % self._lastBalancing)
 
-            if Voltage >= CVL_BALANCING:
+            if self._fn._full_charge_reached(
+                Voltage,
+                CVL_BALANCING,
+                settings.OWN_SOC_FULL_VOLTAGE or None,
+                cellVoltages_dict.values(),
+                settings.OWN_SOC_FULL_CELL_MEDIAN_VOLTAGE or None,
+            ):
                 # reset Coulumb counter to 100%
                 self._ownCharge = InstalledCapacity
 

--- a/functions.py
+++ b/functions.py
@@ -65,6 +65,38 @@ class Functions:
         with open("/sys/firmware/devicetree/base/model", "r") as f:
             return f.readline().strip()
 
+    def _median(self, values):
+        values = sorted(value for value in values if value is not None)
+        if not values:
+            return None
+
+        mid = len(values) // 2
+        if len(values) % 2:
+            return values[mid]
+
+        return (values[mid - 1] + values[mid]) / 2
+
+    def _full_charge_reached(
+        self,
+        pack_voltage,
+        balancing_voltage,
+        own_soc_full_voltage=None,
+        cell_voltages=None,
+        own_soc_full_cell_median_voltage=None,
+    ):
+        if pack_voltage >= balancing_voltage:
+            return True
+        if own_soc_full_voltage is not None and pack_voltage >= own_soc_full_voltage:
+            return True
+        if own_soc_full_cell_median_voltage is None or cell_voltages is None:
+            return False
+
+        median_cell_voltage = self._median(cell_voltages)
+        if median_cell_voltage is None:
+            return False
+
+        return median_cell_voltage >= own_soc_full_cell_median_voltage
+
 
 ################
 # test program #

--- a/settings.py
+++ b/settings.py
@@ -210,6 +210,8 @@ OWN_SOC: bool = get_bool_from_config("DEFAULT", "OWN_SOC")
 ZERO_SOC: bool = get_bool_from_config("DEFAULT", "ZERO_SOC")
 MAX_CELL_VOLTAGE_SOC_FULL: float = get_float_from_config("DEFAULT", "MAX_CELL_VOLTAGE_SOC_FULL")
 MIN_CELL_VOLTAGE_SOC_EMPTY: float = get_float_from_config("DEFAULT", "MIN_CELL_VOLTAGE_SOC_EMPTY")
+OWN_SOC_FULL_VOLTAGE: float = get_float_from_config("DEFAULT", "OWN_SOC_FULL_VOLTAGE")
+OWN_SOC_FULL_CELL_MEDIAN_VOLTAGE: float = get_float_from_config("DEFAULT", "OWN_SOC_FULL_CELL_MEDIAN_VOLTAGE")
 CHARGE_SAVE_PRECISION: float = get_float_from_config("DEFAULT", "CHARGE_SAVE_PRECISION")
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,54 @@
+import unittest
+
+from functions import Functions
+
+
+class FunctionsTests(unittest.TestCase):
+    def setUp(self):
+        self.functions = Functions()
+
+    def test_median_ignores_none_values(self):
+        self.assertAlmostEqual(self.functions._median([3.4, None, 3.6, 3.5]), 3.5)
+
+    def test_reaches_configured_pack_voltage_before_balancing_voltage(self):
+        self.assertTrue(
+            self.functions._full_charge_reached(
+                pack_voltage=63.0,
+                balancing_voltage=67.2,
+                own_soc_full_voltage=63.0,
+            )
+        )
+
+    def test_reaches_configured_median_cell_voltage_before_balancing_voltage(self):
+        self.assertTrue(
+            self.functions._full_charge_reached(
+                pack_voltage=62.9,
+                balancing_voltage=67.2,
+                own_soc_full_voltage=63.0,
+                cell_voltages=[3.45, 3.50, 3.54],
+                own_soc_full_cell_median_voltage=3.5,
+            )
+        )
+
+    def test_reaches_existing_balancing_voltage_without_extra_thresholds(self):
+        self.assertTrue(
+            self.functions._full_charge_reached(
+                pack_voltage=67.2,
+                balancing_voltage=67.2,
+            )
+        )
+
+    def test_does_not_mark_full_below_all_thresholds(self):
+        self.assertFalse(
+            self.functions._full_charge_reached(
+                pack_voltage=62.9,
+                balancing_voltage=67.2,
+                own_soc_full_voltage=63.0,
+                cell_voltages=[3.45, 3.47, 3.49, 3.49],
+                own_soc_full_cell_median_voltage=3.5,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- allow the own SoC reset logic to mark the battery full using an optional pack-voltage threshold\n- add an optional median-cell-voltage threshold as another full-charge signal\n- cover the new helper logic with unit tests\n\n## Testing\n- python3 -m unittest discover -s tests -v\n- python3 -m py_compile functions.py settings.py aggregatebatteries.py\n