### PR TITLE
fix: parse USE_SMARTSHUNTS as bool OR list (documented list-form selector silently coerced to False)

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -92,6 +92,64 @@ def get_bool_from_config(group: str, option: str) -> bool:
     return config[group].get(option, "False").lower() == "true"
 
 
+def get_smartshunts_from_config(group: str, option: str):
+    """
+    Get a SmartShunt selector from the config file.
+
+    The driver's USE_SMARTSHUNTS handling (see dbus-aggregate-batteries.py)
+    accepts either a bool ("True"/"False" — use all or none of the available
+    SmartShunts) or a list of VRM instance ids and/or shunt CustomNames
+    (e.g. ``[277]``, ``[279, 280]``, ``["MyShunt", 279]``). The list form is
+    documented in config.default.ini but won't reach the driver if parsed as
+    a plain bool, so this helper handles both cases.
+
+    Uses ``json.loads`` for list parsing (no code execution).
+
+    :param group: Group in the config file
+    :param option: Option in the config file
+    :return: bool or list
+    """
+    import json
+
+    raw = config[group].get(option, "False").strip()
+    if not raw:
+        return False
+    # Bool forms first
+    low = raw.lower()
+    if low in ("true", "yes", "1"):
+        return True
+    if low in ("false", "no", "0"):
+        return False
+    # List form: accept Python single-quoted strings by normalising to JSON
+    if raw.startswith("[") and raw.endswith("]"):
+        candidate = raw.replace("'", '"')
+        try:
+            val = json.loads(candidate)
+        except (ValueError, TypeError):
+            val = None
+        if isinstance(val, list):
+            # Each element must be int (VRM instance) or str (custom name).
+            # The driver match loop only handles those two types; bool/float/None
+            # would crash it with a confusing error later, so reject up front.
+            # bool is a subclass of int in Python — exclude it explicitly.
+            bad = [
+                (idx, item)
+                for idx, item in enumerate(val)
+                if isinstance(item, bool) or not isinstance(item, (int, str))
+            ]
+            if bad:
+                errors_in_config.append(
+                    f"Invalid {option} list elements: {bad!r}. "
+                    "Each entry must be an int (VRM instance) or str (custom name)."
+                )
+                return False
+            return val
+    errors_in_config.append(
+        f"Invalid {option} value: {raw!r}. Expected True/False or list like [277]."
+    )
+    return False
+
+
 def get_float_from_config(group: str, option: str, default_value: float = 0) -> float:
     """
     Get a float value from the config file.
@@ -203,7 +261,7 @@ TIME_BEFORE_RESTART: int = get_int_from_config("DEFAULT", "TIME_BEFORE_RESTART")
 
 # ----- Options -----
 CURRENT_FROM_VICTRON: bool = get_bool_from_config("DEFAULT", "CURRENT_FROM_VICTRON")
-USE_SMARTSHUNTS: bool = get_bool_from_config("DEFAULT", "USE_SMARTSHUNTS")
+USE_SMARTSHUNTS = get_smartshunts_from_config("DEFAULT", "USE_SMARTSHUNTS")
 INVERT_SMARTSHUNTS: bool = get_bool_from_config("DEFAULT", "INVERT_SMARTSHUNTS")
 IGNORE_SMARTSHUNT_ABSENCE: bool = get_bool_from_config("DEFAULT", "IGNORE_SMARTSHUNT_ABSENCE")
 OWN_SOC: bool = get_bool_from_config("DEFAULT", "OWN_SOC")


### PR DESCRIPTION
## Problem

The driver supports two forms for `USE_SMARTSHUNTS`:

1. A bool — use all available SmartShunts (`True`) or none (`False`).
2. A list of VRM instance ids and/or shunt CustomNames — use only the matching ones.

Form 2 is documented in `config.default.ini` (lines 121–140) with examples like:

```ini
USE_SMARTSHUNTS = [278]
USE_SMARTSHUNTS = [279, 280]
USE_SMARTSHUNTS = ["MyShunt", 279]
```

and the driver code at `dbus-aggregate-batteries.py` (~lines 395–405) explicitly branches on `isinstance(settings.USE_SMARTSHUNTS, (list, tuple))`:

```python
elif isinstance(settings.USE_SMARTSHUNTS, (list, tuple)):
    use_smartshunts = len(settings.USE_SMARTSHUNTS) > 0
    if use_smartshunts:
        NR_SMARTSHUNTS = len(settings.USE_SMARTSHUNTS)
```

But `settings.py` reads it via `get_bool_from_config`, which does:

```python
return config[group].get(option, "False").lower() == "true"
```

So `USE_SMARTSHUNTS = [278]` becomes the string `"[278]"`, lowercased to `"[278]"`, compared against `"true"` → `False`. The list value never reaches the driver, the list-form branch is dead code, and the documented selector silently doesn't work.

I confirmed this on my own install: `settings.USE_SMARTSHUNTS = False  type=bool` despite `config.ini` having `USE_SMARTSHUNTS = [277]`. The shunt selection log line `"... added, named as: ..."` never fires, and the success log shows `"> N batteries found."` instead of `"N batteries and M SmartShunts found"`.

## Fix

Add a dedicated `get_smartshunts_from_config(group, option)` helper that parses both forms:

- `True` / `False` / `yes` / `no` / `1` / `0` (case-insensitive) → bool
- `[277]` / `[277, 279]` / `["MyShunt", 279]` → list (uses `json.loads` after normalising single quotes — no eval/literal-eval, no code execution)
- empty → `False`
- anything else → appends to `errors_in_config`, returns `False`

Each list element is validated to be `int` (VRM instance) or `str` (custom name); `bool`/`float`/`None` are rejected with a clear error message rather than being passed to the driver where they'd cause confusing failures deeper in the match loop. (Note `bool` is excluded explicitly because `isinstance(True, int)` is `True` in Python.)

Apply the new helper to `USE_SMARTSHUNTS` at the import site. **No driver-side changes are needed** — the existing `isinstance(..., (list, tuple))` branches already handle the list form correctly.

## Compatibility

- Bool values continue to behave identically.
- List values now actually work as documented.
- Invalid values that previously coerced to `False` silently now appear in `errors_in_config` (visible during startup), which is strictly better.

## Local verification

```
'[277]'                   -> [277]
'[277, 279]'              -> [277, 279]
"['Shunt', 279]"          -> ['Shunt', 279]
'[True]'                  -> rejected (not valid JSON, error logged)
'[1.5]'                   -> rejected (per-element validation, error logged)
'[null]'                  -> rejected (per-element validation, error logged)
'[]'                      -> []
'True'                    -> True
'False'                   -> False
''                        -> False
'random'                  -> rejected (error logged)
```

After deploying the patch on my Cerbo, aggregate's startup log now shows:

```
SmartShunt 500A/50mV [277] added, named as: SmartShunt LFP.
2 batteries and 1 SmartShunts found
```

and aggregate's `/Dc/0/Current` correctly reflects the configured shunt's reading.