### PR TITLE
pylontech support

### DIFF
--- a/config.default.ini
+++ b/config.default.ini
@@ -80,6 +80,10 @@ TIME_BEFORE_RESTART = 15
 ; The Victron current measurement is very precise
 CURRENT_FROM_VICTRON = False
 
+; Enable compatibility mode for native CAN batteries such as Pylontech.
+; Default False keeps the original safety behaviour unchanged.
+CAN_batteries = False
+
 ; Use SmartShunts for total current measurement and control which ones to use:
 ; - False or an empty list means not to use any SmartShunts
 ; - True uses all available SmartShunts

--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -877,9 +877,29 @@ class DbusAggBatService(object):
                 # DC
                 # to detect error
                 step = "Read V, I, P"
-                Voltage += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Voltage")
-                Current += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Current")
-                Power += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Power")
+                voltage_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Voltage")
+                current_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Current")
+                power_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Power")
+
+                # Some battery services can temporarily publish None on D-Bus while updating.
+                # Do not add None to the aggregate values. Try to recover voltage from
+                # /Voltages/Sum and power from V*I; otherwise trigger the existing read retry.
+                if voltage_get is None:
+                    voltage_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Voltages/Sum")
+
+                if power_get is None and voltage_get is not None and current_get is not None:
+                    power_get = voltage_get * current_get
+
+                if voltage_get is None or current_get is None or power_get is None:
+                    raise ValueError(
+                        "Missing mandatory D-Bus value while reading battery %s: "
+                        "Voltage=%s, Current=%s, Power=%s"
+                        % (i, voltage_get, current_get, power_get)
+                    )
+
+                Voltage += voltage_get
+                Current += current_get
+                Power += power_get
 
                 # Capacity
                 step = "Read and calculate capacity, SoC, Time to go"

--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -4,6 +4,8 @@
 Service to aggregate multiple serial batteries https://github.com/mr-manuel/venus-os_dbus-serialbattery
 to one virtual battery.
 
+modified by DJ0ABR to support Pylontech Batteries and mixed configurations made from Pylontech and DIY batteries
+
 Python location on Venus:
 /usr/bin/python3.8
 /usr/lib/python3.8/site-packages/
@@ -499,12 +501,12 @@ class DbusAggBatService(object):
                                 )
 
                         # Check if Nr. of cells is equal
-                        if self._dbusMon.dbusmon.get_value(service, "/System/NrOfCellsPerBattery") != settings.NR_OF_CELLS_PER_BATTERY:
+                        nr_of_cells = self._dbusMon.dbusmon.get_value(service, "/System/NrOfCellsPerBattery")
+
+                        if nr_of_cells is not None and nr_of_cells != settings.NR_OF_CELLS_PER_BATTERY:
                             logging.error("     |- Number of battery cells does not match config:")
-                            logging.error(
-                                "        |- Cells found in battery:         %d" % (self._dbusMon.dbusmon.get_value(service, "/System/NrOfCellsPerBattery"))
-                            )
-                            logging.error("        |- Cells specified in config file: %d" % (settings.NR_OF_CELLS_PER_BATTERY))
+                            logging.error("        |- Cells found in battery:         %d" % nr_of_cells)
+                            logging.error("        |- Cells specified in config file: %d" % settings.NR_OF_CELLS_PER_BATTERY)
                             logging.error("Exiting...")
                             tt.sleep(settings.TIME_BEFORE_RESTART)
                             sys.exit(1)
@@ -884,11 +886,21 @@ class DbusAggBatService(object):
                 InstalledCapacity += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/InstalledCapacity")
 
                 if not settings.OWN_SOC:
-                    ConsumedAmphours += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/ConsumedAmphours")
-                    Capacity += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Capacity")
+                    ConsumedAmphours += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/ConsumedAmphours") or 0
+                    #Capacity += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Capacity") or 0
+                    capacity_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Capacity")
+
+                    if capacity_get is not None:
+                        Capacity += capacity_get
+                    else:
+                        installed_capacity_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/InstalledCapacity")
+                        soc_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Soc")
+
+                        if installed_capacity_get is not None and soc_get is not None:
+                            Capacity += installed_capacity_get * soc_get / 100
                     Soc += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Soc") * self._dbusMon.dbusmon.get_value(
                         self._batteries_dict[i], "/InstalledCapacity"
-                    )
+                    ) or 0
                     ttg = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/TimeToGo")
                     if (ttg is not None) and (TimeToGo is not None):
                         TimeToGo += ttg * self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/InstalledCapacity")
@@ -933,13 +945,17 @@ class DbusAggBatService(object):
 
                 # here an exception is raised and new read trial initiated if None is on Dbus
                 volt_sum_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Voltages/Sum")
+
                 if volt_sum_get is not None:
                     VoltagesSum_dict[i] = volt_sum_get
                 else:
-                    raise TypeError(
-                        f"Battery {i} returns None value of /Voltages/Sum. Please check, if the setting "
-                        + "'BATTERY_CELL_DATA_FORMAT=1' in dbus-serialbattery config"
-                    )
+                    max_cell_voltage = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/System/MaxCellVoltage")
+                    min_cell_voltage = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/System/MinCellVoltage")
+
+                    if max_cell_voltage is not None and min_cell_voltage is not None:
+                        VoltagesSum_dict[i] = ((max_cell_voltage + min_cell_voltage) / 2) * settings.NR_OF_CELLS_PER_BATTERY
+                    else:
+                        VoltagesSum_dict[i] = 0
 
                 # Battery state
                 step = "Read battery state"
@@ -1071,9 +1087,9 @@ class DbusAggBatService(object):
             else:
                 MaxChargeVoltage = self._fn._min(MaxChargeVoltage_list)
 
-            MaxChargeCurrent = self._fn._min(MaxChargeCurrent_list) * settings.NR_OF_BATTERIES
+            MaxChargeCurrent = sum(MaxChargeCurrent_list)
 
-            MaxDischargeCurrent = self._fn._min(MaxDischargeCurrent_list) * settings.NR_OF_BATTERIES
+            MaxDischargeCurrent = sum(MaxDischargeCurrent_list)
 
         AllowToCharge = self._fn._min(AllowToCharge_list)
         AllowToDischarge = self._fn._min(AllowToDischarge_list)

--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -4,8 +4,6 @@
 Service to aggregate multiple serial batteries https://github.com/mr-manuel/venus-os_dbus-serialbattery
 to one virtual battery.
 
-modified by DJ0ABR to support Pylontech Batteries and mixed configurations made from Pylontech and DIY batteries
-
 Python location on Venus:
 /usr/bin/python3.8
 /usr/lib/python3.8/site-packages/
@@ -503,7 +501,15 @@ class DbusAggBatService(object):
                         # Check if Nr. of cells is equal
                         nr_of_cells = self._dbusMon.dbusmon.get_value(service, "/System/NrOfCellsPerBattery")
 
-                        if nr_of_cells is not None and nr_of_cells != settings.NR_OF_CELLS_PER_BATTERY:
+                        if settings.CAN_batteries:
+                            if nr_of_cells is not None and nr_of_cells != settings.NR_OF_CELLS_PER_BATTERY:
+                                logging.error("     |- Number of battery cells does not match config:")
+                                logging.error("        |- Cells found in battery:         %d" % nr_of_cells)
+                                logging.error("        |- Cells specified in config file: %d" % settings.NR_OF_CELLS_PER_BATTERY)
+                                logging.error("Exiting...")
+                                tt.sleep(settings.TIME_BEFORE_RESTART)
+                                sys.exit(1)
+                        elif nr_of_cells != settings.NR_OF_CELLS_PER_BATTERY:
                             logging.error("     |- Number of battery cells does not match config:")
                             logging.error("        |- Cells found in battery:         %d" % nr_of_cells)
                             logging.error("        |- Cells specified in config file: %d" % settings.NR_OF_CELLS_PER_BATTERY)
@@ -877,50 +883,62 @@ class DbusAggBatService(object):
                 # DC
                 # to detect error
                 step = "Read V, I, P"
-                voltage_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Voltage")
-                current_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Current")
-                power_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Power")
 
-                # Some battery services can temporarily publish None on D-Bus while updating.
-                # Do not add None to the aggregate values. Try to recover voltage from
-                # /Voltages/Sum and power from V*I; otherwise trigger the existing read retry.
-                if voltage_get is None:
-                    voltage_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Voltages/Sum")
+                if settings.CAN_batteries:
+                    voltage_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Voltage")
+                    current_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Current")
+                    power_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Power")
 
-                if power_get is None and voltage_get is not None and current_get is not None:
-                    power_get = voltage_get * current_get
+                    if voltage_get is None:
+                        voltage_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Voltages/Sum")
 
-                if voltage_get is None or current_get is None or power_get is None:
-                    raise ValueError(
-                        "Missing mandatory D-Bus value while reading battery %s: "
-                        "Voltage=%s, Current=%s, Power=%s"
-                        % (i, voltage_get, current_get, power_get)
-                    )
+                    if power_get is None and voltage_get is not None and current_get is not None:
+                        power_get = voltage_get * current_get
 
-                Voltage += voltage_get
-                Current += current_get
-                Power += power_get
+                    if voltage_get is None or current_get is None or power_get is None:
+                        raise ValueError(
+                            "Missing mandatory D-Bus value while reading battery %s: "
+                            "Voltage=%s, Current=%s, Power=%s"
+                            % (i, voltage_get, current_get, power_get)
+                        )
+
+                    Voltage += voltage_get
+                    Current += current_get
+                    Power += power_get
+                else:
+                    Voltage += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Voltage")
+                    Current += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Current")
+                    Power += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Power")
 
                 # Capacity
                 step = "Read and calculate capacity, SoC, Time to go"
                 InstalledCapacity += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/InstalledCapacity")
 
                 if not settings.OWN_SOC:
-                    ConsumedAmphours += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/ConsumedAmphours") or 0
-                    #Capacity += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Capacity") or 0
-                    capacity_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Capacity")
+                    if settings.CAN_batteries:
+                        ConsumedAmphours += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/ConsumedAmphours") or 0
+                        capacity_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Capacity")
 
-                    if capacity_get is not None:
-                        Capacity += capacity_get
-                    else:
-                        installed_capacity_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/InstalledCapacity")
+                        if capacity_get is not None:
+                            Capacity += capacity_get
+                        else:
+                            installed_capacity_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/InstalledCapacity")
+                            soc_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Soc")
+
+                            if installed_capacity_get is not None and soc_get is not None:
+                                Capacity += installed_capacity_get * soc_get / 100
+
                         soc_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Soc")
+                        installed_capacity_get = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/InstalledCapacity")
 
-                        if installed_capacity_get is not None and soc_get is not None:
-                            Capacity += installed_capacity_get * soc_get / 100
-                    Soc += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Soc") * self._dbusMon.dbusmon.get_value(
-                        self._batteries_dict[i], "/InstalledCapacity"
-                    ) or 0
+                        if soc_get is not None and installed_capacity_get is not None:
+                            Soc += soc_get * installed_capacity_get
+                    else:
+                        ConsumedAmphours += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/ConsumedAmphours")
+                        Capacity += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Capacity")
+                        Soc += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Soc") * self._dbusMon.dbusmon.get_value(
+                            self._batteries_dict[i], "/InstalledCapacity"
+                        )
                     ttg = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/TimeToGo")
                     if (ttg is not None) and (TimeToGo is not None):
                         TimeToGo += ttg * self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/InstalledCapacity")
@@ -968,7 +986,7 @@ class DbusAggBatService(object):
 
                 if volt_sum_get is not None:
                     VoltagesSum_dict[i] = volt_sum_get
-                else:
+                elif settings.CAN_batteries:
                     max_cell_voltage = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/System/MaxCellVoltage")
                     min_cell_voltage = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/System/MinCellVoltage")
 
@@ -976,6 +994,11 @@ class DbusAggBatService(object):
                         VoltagesSum_dict[i] = ((max_cell_voltage + min_cell_voltage) / 2) * settings.NR_OF_CELLS_PER_BATTERY
                     else:
                         VoltagesSum_dict[i] = 0
+                else:
+                    raise TypeError(
+                        f"Battery {i} returns None value of /Voltages/Sum. Please check, if the setting "
+                        + "'BATTERY_CELL_DATA_FORMAT=1' in dbus-serialbattery config"
+                    )
 
                 # Battery state
                 step = "Read battery state"
@@ -1107,9 +1130,12 @@ class DbusAggBatService(object):
             else:
                 MaxChargeVoltage = self._fn._min(MaxChargeVoltage_list)
 
-            MaxChargeCurrent = sum(MaxChargeCurrent_list)
-
-            MaxDischargeCurrent = sum(MaxDischargeCurrent_list)
+            if settings.CAN_batteries:
+                MaxChargeCurrent = sum(MaxChargeCurrent_list)
+                MaxDischargeCurrent = sum(MaxDischargeCurrent_list)
+            else:
+                MaxChargeCurrent = self._fn._min(MaxChargeCurrent_list) * settings.NR_OF_BATTERIES
+                MaxDischargeCurrent = self._fn._min(MaxDischargeCurrent_list) * settings.NR_OF_BATTERIES
 
         AllowToCharge = self._fn._min(AllowToCharge_list)
         AllowToDischarge = self._fn._min(AllowToDischarge_list)

--- a/settings.py
+++ b/settings.py
@@ -261,6 +261,7 @@ TIME_BEFORE_RESTART: int = get_int_from_config("DEFAULT", "TIME_BEFORE_RESTART")
 
 # ----- Options -----
 CURRENT_FROM_VICTRON: bool = get_bool_from_config("DEFAULT", "CURRENT_FROM_VICTRON")
+CAN_batteries: bool = get_bool_from_config("DEFAULT", "CAN_batteries")
 USE_SMARTSHUNTS = get_smartshunts_from_config("DEFAULT", "USE_SMARTSHUNTS")
 INVERT_SMARTSHUNTS: bool = get_bool_from_config("DEFAULT", "INVERT_SMARTSHUNTS")
 SMARTSHUNT_AS_BATTERY_CURRENT: bool = get_bool_from_config("DEFAULT", "SMARTSHUNT_AS_BATTERY_CURRENT")


### PR DESCRIPTION
This PR improves compatibility with native CAN bus batteries such as Pylontech.

The current implementation assumes that all batteries provide the same DBus paths as dbus-serialbattery. Native CAN batteries often do not expose:

* /System/NrOfCellsPerBattery
* /Voltages/Sum
* /Capacity

Changes:

* Ignore NrOfCellsPerBattery validation if the DBus path is not available.
* Add fallback calculation for Voltages/Sum using MinCellVoltage and MaxCellVoltage.
* Add fallback calculation for Capacity using InstalledCapacity and SoC.
* Use the sum of MaxChargeCurrent and MaxDischargeCurrent values from all batteries instead of min(current) * battery_count.

Tested successfully with:

* Pylontech battery via CAN
* JK-BMS battery via dbus-serialbattery

Both batteries are now correctly aggregated and can be used with DVCC.
