### PR TITLE
fix: handle None temperature values from BMS types that don't provide temperature data

### DIFF
--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -947,7 +947,8 @@ class DbusAggBatService(object):
 
                 # Temperature
                 step = "Read temperatures"
-                Temperature += self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Temperature")
+                _temp = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Dc/0/Temperature")
+                Temperature += _temp if _temp is not None else 0
                 MaxCellTemp_dict[
                     "%s: %s"
                     % (
@@ -1060,12 +1061,21 @@ class DbusAggBatService(object):
                 AllowToBalance_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Io/AllowToBalance"))
 
             step = "Find max. and min. cell temperature of all batteries"
-            # placed in try-except structure for the case if some values are of None.
-            # The _max() and _min() don't work with dictionaries
-            MaxTempCellId = max(MaxCellTemp_dict, key=MaxCellTemp_dict.get)
-            MaxCellTemp = MaxCellTemp_dict[MaxTempCellId]
-            MinTempCellId = min(MinCellTemp_dict, key=MinCellTemp_dict.get)
-            MinCellTemp = MinCellTemp_dict[MinTempCellId]
+            # Filter out None values — some BMS types (e.g. aiobmsble) do not provide temperature data
+            _MaxCellTemp_valid = {k: v for k, v in MaxCellTemp_dict.items() if v is not None}
+            _MinCellTemp_valid = {k: v for k, v in MinCellTemp_dict.items() if v is not None}
+            if _MaxCellTemp_valid:
+                MaxTempCellId = max(_MaxCellTemp_valid, key=_MaxCellTemp_valid.get)
+                MaxCellTemp = _MaxCellTemp_valid[MaxTempCellId]
+            else:
+                MaxTempCellId = None
+                MaxCellTemp = None
+            if _MinCellTemp_valid:
+                MinTempCellId = min(_MinCellTemp_valid, key=_MinCellTemp_valid.get)
+                MinCellTemp = _MinCellTemp_valid[MinTempCellId]
+            else:
+                MinTempCellId = None
+                MinCellTemp = None
 
             step = "Find max. and min. cell voltage of all batteries"
             # placed in try-except structure for the case if some values are of None.


### PR DESCRIPTION
## Problem

Some BMS types — specifically `aiobmsble` (Topband BMS via Bluetooth, used with [dbus-serialbattery](https://github.com/mr-manuel/venus-os_dbus-serialbattery)) — do not expose temperature readings on the dbus paths `/Dc/0/Temperature` and `/System/Max|MinCellTemperature`. All temperature values are `None`.

This causes the aggregator to crash with two consecutive `TypeError` exceptions and continuously restart:

**Error 1** (~line 950):
```
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```
`Temperature += self._dbusMon.dbusmon.get_value(..., "/Dc/0/Temperature")`

**Error 2** (~line 1065):
```
TypeError: '>' not supported between instances of 'NoneType' and 'NoneType'
```
`max(MaxCellTemp_dict, key=MaxCellTemp_dict.get)` — all values in the dict are `None`

The comment at line 1063 says _"placed in try-except structure for the case if some values are of None"_ — but the existing `try/except` block treats the exception as a read error and counts retries until it exits, rather than handling the None case gracefully.

## Fix

1. **Temperature accumulation**: Guard with a `None` check — add `0` instead of crashing when temperature is unavailable.

2. **Max/min cell temperature**: Filter `None` values out of `MaxCellTemp_dict` / `MinCellTemp_dict` before calling `max()`/`min()`. When no valid temperature data is available from any battery, set `MaxCellTemp` / `MinCellTemp` to `None` (which is already the initialized dbus path value).

## Tested with

- Venus OS v3.75 (large), Raspberry Pi 4 Model B 2GB
- dbus-serialbattery v2.1.20260515dev (nightly)
- 5× ective LC 300L LiFePO4 batteries with Topband BMS via `aiobmsble_topband_bms` Bluetooth driver
- dbus-aggregate-batteries v4.3.20260611-beta