### PR TITLE
style: make the black lint job pass again

### DIFF
--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -898,8 +898,7 @@ class DbusAggBatService(object):
                     if voltage_get is None or current_get is None or power_get is None:
                         raise ValueError(
                             "Missing mandatory D-Bus value while reading battery %s: "
-                            "Voltage=%s, Current=%s, Power=%s"
-                            % (i, voltage_get, current_get, power_get)
+                            "Voltage=%s, Current=%s, Power=%s" % (i, voltage_get, current_get, power_get)
                         )
 
                     Voltage += voltage_get
@@ -1417,7 +1416,7 @@ class DbusAggBatService(object):
         if settings.OWN_SOC:
             Capacity = self._ownCharge
             Soc = 100 * self._ownCharge / InstalledCapacity
-            ConsumedAmphours = - InstalledCapacity + self._ownCharge   # zero if fully charged, otherwise negative
+            ConsumedAmphours = -InstalledCapacity + self._ownCharge  # zero if fully charged, otherwise negative
             if (self._dbusMon.dbusmon.get_value("com.victronenergy.system", "/SystemState/LowSoc") == 0) and (Current < 0):
                 TimeToGo = -3600 * self._ownCharge / Current
             else:

--- a/settings.py
+++ b/settings.py
@@ -132,21 +132,12 @@ def get_smartshunts_from_config(group: str, option: str):
             # The driver match loop only handles those two types; bool/float/None
             # would crash it with a confusing error later, so reject up front.
             # bool is a subclass of int in Python — exclude it explicitly.
-            bad = [
-                (idx, item)
-                for idx, item in enumerate(val)
-                if isinstance(item, bool) or not isinstance(item, (int, str))
-            ]
+            bad = [(idx, item) for idx, item in enumerate(val) if isinstance(item, bool) or not isinstance(item, (int, str))]
             if bad:
-                errors_in_config.append(
-                    f"Invalid {option} list elements: {bad!r}. "
-                    "Each entry must be an int (VRM instance) or str (custom name)."
-                )
+                errors_in_config.append(f"Invalid {option} list elements: {bad!r}. Each entry must be an int (VRM instance) or str (custom name).")
                 return False
             return val
-    errors_in_config.append(
-        f"Invalid {option} value: {raw!r}. Expected True/False or list like [277]."
-    )
+    errors_in_config.append(f"Invalid {option} value: {raw!r}. Expected True/False or list like [277].")
     return False
 
 


### PR DESCRIPTION
The "Black lint and flake8 checks" workflow has been failing on `main` since at least 4.2.20260514-beta — every push and every PR since then reports red, so the check no longer tells you anything.

This is what `black 25.1.0` (the version pinned in the workflow) asks for, and nothing else:

- `settings.py` — three hunks in `get_smartshunts_from_config`, plus joining the two adjacent string literals black leaves behind into one
- `dbus-aggregate-batteries.py` — the `ValueError` message in the battery read loop, and `ConsumedAmphours = - InstalledCapacity` → `-InstalledCapacity`

No functional change. Separated from my other open PRs on purpose, so none of them mixes formatting with behaviour — with this merged, the check goes green for everyone's PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)