### PR TITLE
fix: the internal failure alarm is read from a path that does not exist

### DIFF
--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -1022,7 +1022,7 @@ class DbusAggBatService(object):
                 HighChargeCurrent_alarm_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Alarms/HighChargeCurrent"))
                 HighDischargeCurrent_alarm_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Alarms/HighDischargeCurrent"))
                 CellImbalance_alarm_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Alarms/CellImbalance"))
-                InternalFailure_alarm_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Alarms/InternalFailure_alarm"))
+                InternalFailure_alarm_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Alarms/InternalFailure"))
                 HighChargeTemperature_alarm_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Alarms/HighChargeTemperature"))
                 LowChargeTemperature_alarm_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Alarms/LowChargeTemperature"))
                 HighTemperature_alarm_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Alarms/HighTemperature"))

--- a/dbusmon.py
+++ b/dbusmon.py
@@ -57,7 +57,7 @@ class DbusMon:
                 "/Alarms/HighChargeCurrent": dummy,
                 "/Alarms/HighDischargeCurrent": dummy,
                 "/Alarms/CellImbalance": dummy,
-                "/Alarms/InternalFailure_alarm": dummy,
+                "/Alarms/InternalFailure": dummy,
                 "/Alarms/HighChargeTemperature": dummy,
                 "/Alarms/LowChargeTemperature": dummy,
                 "/Alarms/HighTemperature": dummy,


### PR DESCRIPTION
One line. Found while writing tests for another change.

The per-battery read uses `/Alarms/InternalFailure_alarm`:

```python
InternalFailure_alarm_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Alarms/InternalFailure_alarm"))
```

That path does not exist — the `_alarm` suffix is a fragment of the local variable name. dbus-serialbattery publishes `/Alarms/InternalFailure`, which is also the path this driver publishes the aggregated result on (`self._dbusservice.add_path("/Alarms/InternalFailure", ...)`, and `bus["/Alarms/InternalFailure"] = InternalFailure_alarm`).

## Why it has been invisible

The failure is silent at every step:

1. `get_value()` returns `None` for the unknown path, so `InternalFailure_alarm_list` fills with `None`.
2. `Functions._max()` calls `max()` on that list, which raises `TypeError` on the first comparison — `max([None, None])` raises, not just `max([None, 1])`.
3. `_max()` catches `Exception` and returns `None`.
4. `/Alarms/InternalFailure` is published as `None`, every cycle, with nothing in the log.

So an internal failure reported by any BMS has never propagated through the aggregate. Every other alarm in that block reads a path that exists.

## After

The alarm aggregates like the others. That is the intent, but worth stating plainly: for anyone running a BMS that does report `/Alarms/InternalFailure`, an alarm that was previously dead will now fire.

Kept separate from my other open PRs since it is pre-existing and unrelated to them. No test here — a test needs the driver test harness, which comes with #166; happy to add one on top once you have decided about that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)