### PR TITLE
feat: declare this service as derived, and name the services it aggregates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ On start, the program searches for DBus services:
 The data from DBus are collected, processed and the results are sent back to DBus once per second.
 Dbus monitor defined in dbusmon.py is used instead of VeDbusItemImport which was very resource hungry (since V2.0). I strongly recommend to everyone modifying the code to keep this technique.
 
+### Measurement graph
+
+This driver republishes values it computes from other battery services, so anything summing DC current across the bus would count the same energy twice: once in this service and once in each battery it aggregates. Name matching is the usual workaround and it is fragile — a driver can be renamed, and a user can set any `CustomName`.
+
+The service therefore states what it is, in five string paths shared with the battery drivers:
+
+| Path | Value | Published by | Meaning |
+| --- | --- | --- | --- |
+| `/Measurement/Kind` | `direct` or `derived` | every participant | `direct`: I measure a physical device. `derived`: I compute from other services |
+| `/Measurement/PhysicalDevice` | opaque string | `direct` only | grouping key — two services with the same value measure the same physical thing |
+| `/Measurement/PeerServices` | comma-separated service names | `direct` only | other services observing my physical device |
+| `/Measurement/LineAuthority` | single service name | `direct` only | which service is the truth for line voltage and current |
+| `/Measurement/TracksServices` | comma-separated service names | `derived` only | what I aggregate |
+
+This driver is `derived`, so it publishes `Kind` and `TracksServices` and nothing else: the three `direct` keys identify a physical device and would be meaningless here. `TracksServices` is filled once the battery search completes, sorted and comma separated without spaces, and it names the services actually discovered rather than anything configured.
+
+A consumer can then exclude this service structurally instead of by name, and knows exactly which services it would be double counting.
+
+The full contract — value formats, how a consumer resolves the graph, and what an absent path means — is in [docs/measurement-topology.md](docs/measurement-topology.md). The same document ships with the battery drivers that publish the `direct` half.
+
 ### Smart Shunts as battery current source
 
 By default the aggregate computes bank current as `Quattro/Multiplus + solar chargers + DC-load shunts`. This is correct for most setups, but it cannot see current sources the driver does not enumerate — most notably Orion DC-DC converters (registered as `com.victronenergy.dcdc`), which often carry alternator charge into the battery bank. In that case the driver under-reports charge current and the alternator contribution is invisible to ESS, DVCC and VRM.

--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -177,6 +177,12 @@ class DbusAggBatService(object):
         self._dbusservice.add_path("/FirmwareVersion", VERSION)
         self._dbusservice.add_path("/HardwareVersion", VERSION)
         self._dbusservice.add_path("/Connected", 1)
+        # Measurement-graph declaration: this service re-publishes values
+        # rolled up from other battery services; summing consumers must not
+        # count it alongside its constituents. See docs/measurement-topology.md.
+        # TracksServices is filled once the battery search completes.
+        self._dbusservice.add_path("/Measurement/Kind", "derived")
+        self._dbusservice.add_path("/Measurement/TracksServices", "", writeable=True)
 
         # Create DC paths
         self._dbusservice.add_path(
@@ -624,6 +630,7 @@ class DbusAggBatService(object):
             else:
                 self._timeOld = tt.time()
                 # if current from BMS start the _update loop
+                self._dbusservice["/Measurement/TracksServices"] = ",".join(sorted(self._batteries_dict.values()))
                 GLib.timeout_add_seconds(settings.UPDATE_INTERVAL_DATA, self._update)
 
             # all OK, stop calling this function
@@ -695,6 +702,7 @@ class DbusAggBatService(object):
         else:
             self._timeOld = tt.time()
             # if no MPPTs start the _update loop
+            self._dbusservice["/Measurement/TracksServices"] = ",".join(sorted(self._batteries_dict.values()))
             GLib.timeout_add_seconds(settings.UPDATE_INTERVAL_DATA, self._update)
 
         # all OK, stop calling this function
@@ -731,6 +739,7 @@ class DbusAggBatService(object):
         logging.info("> %d MPPT(s) found." % (mpptsCount))
         if mpptsCount == settings.NR_OF_MPPTS:
             self._timeOld = tt.time()
+            self._dbusservice["/Measurement/TracksServices"] = ",".join(sorted(self._batteries_dict.values()))
             GLib.timeout_add_seconds(settings.UPDATE_INTERVAL_DATA, self._update)
             # all OK, stop calling this function
             return False

--- a/docs/measurement-topology.md
+++ b/docs/measurement-topology.md
@@ -1,0 +1,181 @@
+# Measurement topology on D-Bus
+
+This document describes the `/Measurement/*` paths that this driver publishes,
+and the vocabulary they belong to. It is an interface contract: other services
+on the bus read these paths, so the names, types and value formats below are
+what consumers depend on.
+
+The same document ships with the battery drivers that publish the `direct`
+half of this vocabulary. The schema sections are identical in both copies; only
+the sentences describing what *this* driver publishes differ.
+
+## The problem it solves
+
+A physical battery is often measured twice. The BMS reports pack voltage,
+current and state of charge over its own link; a Victron SmartShunt wired at
+the same terminals reports the same quantities independently. Both appear on
+D-Bus as `com.victronenergy.battery.*` services.
+
+Anything that sums battery services — an aggregator, a DC-system calculator —
+cannot tell from the values alone that these two services describe one battery
+rather than two. It counts the pack twice. On a live system this produced a DC
+load reading of about 20.5 A against a true 13.5 A, which fed into DVCC
+compensation and set the bank oscillating.
+
+This driver is itself a service that must not be double counted: it republishes
+values computed from the battery services it aggregates, so a consumer summing
+DC current across the bus would count the same energy once here and once in
+each constituent.
+
+Consumers cannot infer the relationship, because nothing in the published
+values expresses it. So the services declare it.
+
+## Where the declarations live
+
+On each service, under `/Measurement/` in its own object tree, beside
+`/Dc/0/Voltage` and everything else it publishes. There is no central
+registry and no separate topology service. A consumer discovers the graph by
+walking the services already on the bus and reading these paths.
+
+A service declares only what it can speak for. Victron's own shunt services
+know nothing of this vocabulary and cannot declare anything, so the driver
+that knows about a pairing declares it on their behalf.
+
+## Schema
+
+All values are strings. Which paths a service publishes depends on its `Kind`.
+
+### `/Measurement/Kind`
+
+Required for participation. One of:
+
+| Value | Meaning |
+| --- | --- |
+| `direct` | This service publishes measurements of a physical device it observes. |
+| `derived` | This service computes its values from other services. |
+
+A service that publishes no `Kind` is not part of the graph, and consumers
+must fall back to whatever behaviour they used before.
+
+This driver publishes `derived`.
+
+### `/Measurement/PhysicalDevice`
+
+Published by `direct` services. A stable identifier for the physical device
+being measured. Two services publishing the same value are measuring the
+same physical thing.
+
+**The value is opaque.** Consumers use it only as a grouping key and must
+not parse it. The battery drivers publish `battery:<bms_id>`, for example
+`battery:53_20_B7_D7_F9_E7`, but the format is a convention, not part of
+the contract.
+
+The identifier must be stable across restarts of the publishing service, or
+groups will fragment.
+
+This driver does not publish it: it observes no physical device.
+
+### `/Measurement/PeerServices`
+
+Published by `direct` services that know of other services measuring their
+own physical device. A **comma-separated list** of D-Bus service names:
+
+```
+com.victronenergy.battery.ttyS5
+com.victronenergy.battery.ttyS5,com.victronenergy.battery.ttyS9
+```
+
+Omitted entirely when there are no known peers, rather than published empty —
+the peer set is fixed at registration, so a present-but-empty value would
+falsely suggest a value still to come.
+
+This driver does not publish it: peering is a statement about a physical
+device, which a derived service has none of.
+
+### `/Measurement/LineAuthority`
+
+Published by `direct` services that can say which service should be treated
+as the truth for line voltage and current on their physical device. A single
+D-Bus service name.
+
+Where a shunt is wired at the battery terminals it is normally the authority:
+it measures the line directly, where a BMS may report a filtered or
+deadbanded value.
+
+This driver does not publish it: it is not on any line, and the authority for
+each constituent's line is declared by that constituent.
+
+### `/Measurement/TracksServices`
+
+Published by `derived` services. A comma-separated list of the service names
+whose values this service aggregates.
+
+This driver publishes it, and it is the reason the driver participates at all.
+The value is filled once the battery search completes — it names the services
+actually discovered, sorted and comma separated without spaces, not anything
+configured. It is declared as an empty string at registration and written once
+the search finishes, so a consumer reading it early sees empty rather than a
+half-built list.
+
+## Worked example
+
+Two BLE batteries, each with its own SmartShunt, plus an aggregator:
+
+```
+com.victronenergy.battery.ble_5320b7d7f9e7      (battery driver)
+  /Measurement/Kind            = direct
+  /Measurement/PhysicalDevice  = battery:53_20_B7_D7_F9_E7
+  /Measurement/PeerServices    = com.victronenergy.battery.ttyS5
+  /Measurement/LineAuthority   = com.victronenergy.battery.ttyS5
+
+com.victronenergy.battery.ble_ab807254e0b4      (battery driver)
+  /Measurement/Kind            = direct
+  /Measurement/PhysicalDevice  = battery:AB_80_72_54_E0_B4
+  /Measurement/PeerServices    = com.victronenergy.battery.ttyS6
+  /Measurement/LineAuthority   = com.victronenergy.battery.ttyS6
+
+com.victronenergy.battery.ttyS5                 (SmartShunt, declares nothing)
+com.victronenergy.battery.ttyS6                 (SmartShunt, declares nothing)
+
+com.victronenergy.battery.aggregate             (this driver)
+  /Measurement/Kind            = derived
+  /Measurement/TracksServices  = com.victronenergy.battery.ble_5320b7d7f9e7,
+                                 com.victronenergy.battery.ble_ab807254e0b4
+```
+
+Five battery services are on the bus; two physical batteries exist. The
+declarations are what let a consumer tell the difference.
+
+## How a consumer resolves the graph
+
+For each service on the bus:
+
+1. Read `/Measurement/Kind`. If absent, the service is not participating.
+2. If `derived`, mark it claimed and skip it — this is what prevents an
+   aggregator being summed alongside the constituents it already includes.
+3. If `direct`, read `/Measurement/PhysicalDevice`. Group services by that
+   value, adding everyone named in `/Measurement/PeerServices` to the same
+   group and marking them claimed.
+4. Take `/Measurement/LineAuthority`, when present, as the group's preferred
+   source for line voltage and current.
+
+The result is one representative per physical device. Services that declared
+nothing and were never named as a peer are left to whatever fallback the
+consumer chooses.
+
+## Notes for implementers
+
+- **Absent is meaningful.** Optional paths are omitted rather than published
+  as `None`. Consumers must treat an absent path as "not declared", never as
+  an error.
+- **Registration-time values.** These paths are declared when the service is
+  registered and do not change during its lifetime. A consumer may cache them,
+  and should not treat a transient read failure as a change in topology.
+  `/Measurement/TracksServices` is the one exception in this driver: it is
+  declared empty and written once, when the battery search completes.
+- **Lists are comma-separated strings**, not D-Bus arrays, for the sake of
+  services and tools that read paths as simple text. Consumers should strip
+  whitespace around entries and ignore empty ones.
+- **Naming.** The paths intentionally describe measurement relationships
+  rather than any particular feature, so that other pairing sources can
+  publish the same vocabulary.

--- a/tests/driver_harness.py
+++ b/tests/driver_harness.py
@@ -1,0 +1,699 @@
+#!/usr/bin/env python3
+
+"""
+The one place where the unit tests stub Venus OS and load the driver.
+
+Every suite in ``tests/`` imports this module and nothing else touches
+``sys.modules``.  That is deliberate: the driver's dependencies (``dbus``,
+``gi``/``GLib``, ``vedbus``, ``dbusmonitor``, ``settings``) can only be faked
+once per interpreter, so if each suite installed its own fakes the first import
+would win and every later suite would silently run against a stand-in that was
+built for somebody else's test.  Python imports a module once, so doing the
+stubbing here — unconditionally, never with ``setdefault`` — makes the result
+identical no matter which suite is imported first, in any combination.
+
+What is provided:
+
+* ``FakeGLib`` - records ``idle_add`` / ``timeout_add_seconds`` instead of
+  running a main loop, and can drain the queued idle callbacks on demand, which
+  is what makes the reactive coalescing observable without any timing.
+  ``patch_glib()`` swaps a fresh recorder into the driver for one test.
+* ``dbus`` and ``vedbus`` stubs whose constructors raise, so a test that
+  accidentally builds a real bus object fails loudly instead of hanging.
+* ``dbusmonitor`` stubbed by ``RecordingDbusMonitor``.  ``dbusmon`` itself is
+  *not* stubbed: it is a module under test, and on top of the recorder it
+  constructs nothing real.
+* ``settings``: the real ``settings.py``, executed from a throwaway directory
+  next to a generated ``config.ini`` so the repository's own ``config.ini`` is
+  never read or written.  ``make_config_dir()`` / ``load_settings()`` expose the
+  same machinery to the settings tests, and ``use_stub_settings()`` swaps in a
+  fresh in-memory settings namespace for tests that want to drive the device
+  search with values of their own — an explicit, per-test choice instead of a
+  global race.
+* ``driver`` - ``dbus-aggregate-batteries.py`` loaded by path (its file name
+  contains dashes) and cached, so repeated loads are cheap and consistent.
+* ``RecordingDbusService`` - a fake of the D-Bus service the publish gate wraps,
+  recording registrations and writes separately, and ``new_service()``, the
+  ``object.__new__`` helper every suite uses to build a ``DbusAggBatService``
+  without running its bus-touching ``__init__``.
+
+No driver logic is re-implemented here: this module only supplies the
+scaffolding, so every assertion in the test modules is about what the driver
+itself computed.
+"""
+
+import importlib
+import importlib.util
+import itertools
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(TESTS_DIR)
+DRIVER_PATH = os.path.join(REPO_ROOT, "dbus-aggregate-batteries.py")
+SETTINGS_PATH = os.path.join(REPO_ROOT, "settings.py")
+CONFIG_DEFAULT_PATH = os.path.join(REPO_ROOT, "config.default.ini")
+
+DRIVER_MODULE_NAME = "dbus_aggregate_batteries_under_test"
+
+# Number of cells the scripted batteries report. The driver is told the same
+# number through the settings patch in DriverTestCase.
+NR_OF_CELLS = 4
+
+# The shipped defaults for these two are invalid on purpose ("-1"), forcing the
+# installer to set them. Every generated config.ini gets valid values unless the
+# caller overrides them itself.
+MINIMAL_VALID_CONFIG = {
+    "NR_OF_BATTERIES": "2",
+    "NR_OF_CELLS_PER_BATTERY": "8",
+}
+
+_module_counter = itertools.count()
+
+
+# ---------------------------------------------------------------------------
+# Stand-ins for the modules that only exist on a Venus OS device
+# ---------------------------------------------------------------------------
+
+
+class Unconstructable:
+    """Placeholder for symbols the driver imports but a unit test must never build."""
+
+    def __init__(self, *args, **kwargs):  # pragma: no cover - the point is that it never runs
+        raise AssertionError("real D-Bus objects must not be constructed in unit tests")
+
+
+class FakeGLib:
+    """Records scheduling calls instead of dispatching them on a main loop."""
+
+    MainLoop = Unconstructable
+
+    def __init__(self):
+        self.idle_calls = []
+        """list of (callback, args) queued via idle_add"""
+
+        self.timeout_calls = []
+        """list of (interval, callback, args) queued via timeout_add[_seconds]"""
+
+        self._next_source_id = 0
+
+    def _source_id(self):
+        self._next_source_id += 1
+        return self._next_source_id
+
+    def idle_add(self, callback, *args):
+        self.idle_calls.append((callback, args))
+        return self._source_id()
+
+    def timeout_add(self, interval, callback, *args):
+        self.timeout_calls.append((interval, callback, args))
+        return self._source_id()
+
+    def timeout_add_seconds(self, interval, callback, *args):
+        self.timeout_calls.append((interval, callback, args))
+        return self._source_id()
+
+    @property
+    def scheduled_callbacks(self):
+        """Every callback handed to the main loop, idle and timed alike, in order."""
+        return [callback for callback, _ in self.idle_calls] + [callback for _, callback, _ in self.timeout_calls]
+
+    def run_pending_idle(self):
+        """Run each queued idle callback once, the way the main loop would, and return their results."""
+        pending, self.idle_calls = self.idle_calls, []
+        return [callback(*args) for callback, args in pending]
+
+
+class RecordingDbusMonitor:
+    """Stand-in for velib_python's DbusMonitor that records its constructor arguments."""
+
+    last_instance = None
+
+    def __init__(self, monitorlist, *args, **kwargs):
+        self.monitorlist = monitorlist
+        self.args = args
+        self.kwargs = kwargs
+        RecordingDbusMonitor.last_instance = self
+
+
+def _make_module(name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+def _install_module_stubs():
+    """Register the fake Venus OS modules in sys.modules and return the GLib recorder.
+
+    Entries are assigned, never ``setdefault``-ed: this function runs exactly
+    once (at the first import of this module), and it must not inherit anything
+    a previous import happened to leave behind.
+    """
+    if REPO_ROOT not in sys.path:
+        sys.path.insert(0, REPO_ROOT)
+
+    glib = FakeGLib()
+    repository = _make_module("gi.repository", GLib=glib)
+    gi = _make_module("gi", repository=repository, require_version=lambda *args, **kwargs: None)
+
+    dbus_glib = _make_module("dbus.mainloop.glib", DBusGMainLoop=lambda *args, **kwargs: None)
+    dbus_mainloop = _make_module("dbus.mainloop", glib=dbus_glib)
+    dbus = _make_module(
+        "dbus",
+        mainloop=dbus_mainloop,
+        SystemBus=Unconstructable,
+        SessionBus=Unconstructable,
+        Interface=Unconstructable,
+    )
+
+    vedbus = _make_module("vedbus", VeDbusService=Unconstructable, VeDbusItemImport=Unconstructable)
+
+    # dbusmon is deliberately absent: it is a module under test. With
+    # dbusmonitor recorded rather than real, importing it is harmless.
+    dbusmonitor = _make_module("dbusmonitor", DbusMonitor=RecordingDbusMonitor)
+
+    for name, module in (
+        ("gi", gi),
+        ("gi.repository", repository),
+        ("gi.repository.GLib", glib),
+        ("dbus", dbus),
+        ("dbus.mainloop", dbus_mainloop),
+        ("dbus.mainloop.glib", dbus_glib),
+        ("vedbus", vedbus),
+        ("dbusmonitor", dbusmonitor),
+    ):
+        sys.modules[name] = module
+
+    return glib
+
+
+# ---------------------------------------------------------------------------
+# The real settings.py, executed against a throwaway config
+# ---------------------------------------------------------------------------
+
+
+def make_config_dir(overrides=None, include_user_config=True):
+    """Create a temp dir with settings.py, config.default.ini and a config.ini.
+
+    settings.py reads config.default.ini and then config.ini relative to its own
+    location, and calls sys.exit(1) when the result is invalid (the shipped
+    defaults are deliberately invalid placeholders). Copying it next to a
+    generated config.ini exercises the real parsing without ever touching the
+    repository's own config.ini.
+
+    :param overrides: mapping of option -> value written to the config.ini
+    :param include_user_config: when False no config.ini is written at all
+    :return: path of the temporary directory (caller is responsible for removal)
+    """
+    directory = tempfile.mkdtemp(prefix="aggbat-cfg-")
+    shutil.copy(SETTINGS_PATH, directory)
+    shutil.copy(CONFIG_DEFAULT_PATH, directory)
+    if include_user_config:
+        options = dict(MINIMAL_VALID_CONFIG)
+        options.update(overrides or {})
+        lines = ["[DEFAULT]"] + ["%s = %s" % (key, value) for key, value in options.items()]
+        with open(os.path.join(directory, "config.ini"), "w") as handle:
+            handle.write("\n".join(lines) + "\n")
+    return directory
+
+
+def new_settings_module(directory, name=None):
+    """Return a not-yet-executed module object for the settings.py copy in ``directory``."""
+    if name is None:
+        name = "settings_under_test_%d" % next(_module_counter)
+    spec = importlib.util.spec_from_file_location(name, os.path.join(directory, "settings.py"))
+    module = importlib.util.module_from_spec(spec)
+    module.__spec__ = spec
+    return module
+
+
+def exec_settings(module):
+    """Execute a module returned by :func:`new_settings_module`.
+
+    ``time.sleep`` is patched out because settings.py sleeps 60 s before exiting
+    on a configuration error.
+    """
+    with mock.patch("time.sleep"):
+        module.__spec__.loader.exec_module(module)
+
+
+def load_settings(directory):
+    """Execute the settings.py copy in ``directory`` and return its module.
+
+    The module object is available to the caller even when execution ends in
+    ``SystemExit``, so ``errors_in_config`` can be inspected:
+
+        module = driver_harness.new_settings_module(directory)
+        with self.assertRaises(SystemExit):
+            driver_harness.exec_settings(module)
+    """
+    module = new_settings_module(directory)
+    exec_settings(module)
+    return module
+
+
+def _install_settings():
+    """Execute the real settings.py once and register it as ``settings``."""
+    directory = make_config_dir()
+    try:
+        module = new_settings_module(directory, name="settings")
+        sys.modules["settings"] = module
+        exec_settings(module)
+        return module
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# The driver itself
+# ---------------------------------------------------------------------------
+
+
+def load_driver():
+    """Import dbus-aggregate-batteries.py by path (its name is not a valid module name)."""
+    if DRIVER_MODULE_NAME not in sys.modules:
+        spec = importlib.util.spec_from_file_location(DRIVER_MODULE_NAME, DRIVER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[DRIVER_MODULE_NAME] = module
+        try:
+            spec.loader.exec_module(module)
+        except BaseException:
+            del sys.modules[DRIVER_MODULE_NAME]
+            raise
+    return sys.modules[DRIVER_MODULE_NAME]
+
+
+def load_dbusmon():
+    """Import the real dbusmon module on top of the recording dbusmonitor."""
+    return importlib.import_module("dbusmon")
+
+
+GLIB = _install_module_stubs()
+settings = _install_settings()
+driver = load_driver()
+
+
+def patch_glib(test_case):
+    """Give ``test_case`` a fresh GLib recorder for the duration of the test."""
+    glib = FakeGLib()
+    patcher = mock.patch.object(driver, "GLib", glib)
+    patcher.start()
+    test_case.addCleanup(patcher.stop)
+    return glib
+
+
+# ---------------------------------------------------------------------------
+# An in-memory settings namespace, for tests that drive the device search
+# ---------------------------------------------------------------------------
+
+# The device search reads a lot of settings and the tests vary them, so they run
+# against a stand-in rather than the parsed config. use_stub_settings() hands out
+# a fresh one per test, which is the per-test reset: no test can leak a value
+# into the next one, and the real settings module is restored afterwards.
+DEFAULT_STUB_SETTINGS = {
+    "BATTERY_SERVICE_NAME": "com.victronenergy.battery",
+    "DCLOAD_SERVICE_NAME": "com.victronenergy.dcload",
+    "BATTERY_PRODUCT_NAME_PATH": "/ProductName",
+    "BATTERY_PRODUCT_NAME": "SerialBattery",
+    "BATTERY_INSTANCE_NAME_PATH": "/CustomName",
+    "SMARTSHUNT_INSTANCE_NAME_PATH": "/CustomName",
+    "SMARTSHUNT_NAME_KEYWORD": "SmartShunt",
+    "USE_SMARTSHUNTS": False,
+    "SEND_CELL_VOLTAGES": 0,
+    "NR_OF_CELLS_PER_BATTERY": 16,
+    "CAN_batteries": False,
+    "NR_OF_BATTERIES": 2,
+    "CURRENT_FROM_VICTRON": False,
+    "MULTI_KEYWORD": "com.victronenergy.vebus",
+    "NR_OF_MPPTS": 0,
+    "MPPT_KEYWORD": "com.victronenergy.solarcharger",
+    "SEARCH_TRIALS": 10,
+    "UPDATE_INTERVAL_DATA": 1000,
+    "UPDATE_INTERVAL_FIND_DEVICES": 3,
+    "TIME_BEFORE_RESTART": 0,
+    "OWN_CHARGE_PARAMETERS": False,
+}
+
+
+def new_stub_settings(**overrides):
+    """A fresh settings namespace carrying DEFAULT_STUB_SETTINGS plus ``overrides``."""
+    values = dict(DEFAULT_STUB_SETTINGS)
+    values.update(overrides)
+    return _make_module("settings_stub", **values)
+
+
+def use_stub_settings(test_case, **overrides):
+    """Swap a fresh settings stub into the driver for the duration of ``test_case``."""
+    stub = new_stub_settings(**overrides)
+    patcher = mock.patch.object(driver, "settings", stub)
+    patcher.start()
+    test_case.addCleanup(patcher.stop)
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# Test doubles for the D-Bus side
+# ---------------------------------------------------------------------------
+
+
+class _RecordingServiceContext:
+    """Stand-in for velib_python's ``ServiceContext``."""
+
+    def __init__(self, service):
+        self._service = service
+
+    def __setitem__(self, path, value):
+        self._service._write(path, value)
+
+    def __getitem__(self, path):
+        return self._service[path]
+
+
+class RecordingDbusService:
+    """Records every registration and every write that reaches the D-Bus layer.
+
+    Registration through ``add_path`` seeds the published value but is not a
+    write, which is the distinction the publish gate is built on:
+    ``ServiceContext.__getitem__`` returns the currently published value, and
+    ``VeDbusItemExport._local_set_value`` drops a write whose value is unchanged
+    (so "not written" and "not emitted on D-Bus" are the same thing).
+    """
+
+    def __init__(self):
+        self.values = {}
+        self.written = []
+        """list of (path, value) that went through __setitem__, in order"""
+
+        self.add_path_calls = []
+        """list of (path, value, kwargs) passed to add_path, in order"""
+
+        self.enter_count = 0
+        self.exit_count = 0
+        self.registered = False
+
+    # ----- velib-ish API used by the driver -----
+
+    def add_path(self, path, value=None, **kwargs):
+        """Register a path with its initial value. Registration is not a write."""
+        self.add_path_calls.append((path, value, kwargs))
+        self.values[path] = value
+
+    def register(self):
+        self.registered = True
+        return "registered"
+
+    def __enter__(self):
+        self.enter_count += 1
+        return _RecordingServiceContext(self)
+
+    def __exit__(self, *exc):
+        self.exit_count += 1
+        return False
+
+    def __setitem__(self, path, value):
+        self._write(path, value)
+
+    def __getitem__(self, path):
+        if path not in self.values:
+            raise KeyError(path)
+        return self.values[path]
+
+    # ----- test helpers -----
+
+    @property
+    def published(self):
+        """Everything currently on the bus, registered or written."""
+        return self.values
+
+    def writes_to(self, path):
+        """Every value written to ``path``, in order. Registrations are excluded."""
+        return [value for written_path, value in self.written if written_path == path]
+
+    def _write(self, path, value):
+        self.written.append((path, value))
+        self.values[path] = value
+
+    def foreign_write(self, path, value):
+        """Another process writing the path over D-Bus (VeDbusItemExport.SetValue)."""
+        self.values[path] = value
+
+
+class FakeBus:
+    """Stands in for the D-Bus connection: only ``list_names`` is ever used."""
+
+    def __init__(self, names=()):
+        self._names = list(names)
+
+    def list_names(self):
+        return list(self._names)
+
+
+class FakeDbusMonitor:
+    """Stands in for DbusMon().dbusmon: scripted get_value per (service, path)."""
+
+    def __init__(self, values=None, default=0):
+        self._values = dict(values or {})
+        self._default = default
+        self.set_calls = []
+
+    def get_value(self, service, path):
+        return self._values.get((service, path), self._default)
+
+    def set_value(self, service, path, value):
+        self.set_calls.append((service, path, value))
+        return 0
+
+
+class FakeDbusMon:
+    def __init__(self, values=None, default=0):
+        self.dbusmon = FakeDbusMonitor(values, default)
+
+
+class WarningCollector(logging.Handler):
+    """Collects records so a test can assert that nothing was warned."""
+
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    @property
+    def messages(self):
+        return [record.getMessage() for record in self.records]
+
+
+def new_service(**attributes):
+    """Build a DbusAggBatService without running its D-Bus touching __init__.
+
+    Only the attributes a test's code path actually reads have to be set, which
+    is why the real ``__init__`` (it opens a bus) is bypassed entirely.
+    """
+    service = object.__new__(driver.DbusAggBatService)
+    for name, value in attributes.items():
+        setattr(service, name, value)
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Scripted constituent batteries and the base class that drives _update()
+# ---------------------------------------------------------------------------
+
+# Alarm paths the driver reads for every battery.
+ALARM_PATHS = (
+    "/Alarms/LowVoltage",
+    "/Alarms/HighVoltage",
+    "/Alarms/LowCellVoltage",
+    "/Alarms/HighCellVoltage",
+    "/Alarms/LowSoc",
+    "/Alarms/HighChargeCurrent",
+    "/Alarms/HighDischargeCurrent",
+    "/Alarms/CellImbalance",
+    "/Alarms/InternalFailure",
+    "/Alarms/HighChargeTemperature",
+    "/Alarms/LowChargeTemperature",
+    "/Alarms/HighTemperature",
+    "/Alarms/LowTemperature",
+    "/Alarms/BmsCable",
+)
+
+# Values that keep every part of _update() a test is not interested in happy
+# and boring, so that a test only has to vary the values it is about.
+HEALTHY_BATTERY = {
+    "/InstalledCapacity": 100.0,
+    "/ConsumedAmphours": -10.0,
+    "/Capacity": 90.0,
+    "/Soc": 90.0,
+    "/TimeToGo": 3600.0,
+    "/Voltages/Sum": 52.0,
+    "/System/NrOfModulesOnline": 1,
+    "/System/NrOfModulesOffline": 0,
+    "/System/NrOfModulesBlockingCharge": 0,
+    "/System/NrOfModulesBlockingDischarge": 0,
+    "/Info/MaxChargeCurrent": 50.0,
+    "/Info/MaxDischargeCurrent": 50.0,
+    "/Info/MaxChargeVoltage": 55.2,
+    "/Info/ChargeMode": "Bulk",
+    "/Io/AllowToCharge": 1,
+    "/Io/AllowToDischarge": 1,
+    "/Io/AllowToBalance": 1,
+}
+
+
+class Battery:
+    """Scripted D-Bus answers for one constituent battery."""
+
+    def __init__(
+        self,
+        name,
+        voltage=52.0,
+        # zero current by default keeps the Coulomb counter still
+        current=0.0,
+        power=0.0,
+        temperature=22.0,
+        max_cell_voltage=3.35,
+        max_voltage_cell_id=1,
+        min_cell_voltage=3.30,
+        min_voltage_cell_id=2,
+        max_cell_temperature=25.0,
+        max_temperature_cell_id=3,
+        min_cell_temperature=20.0,
+        min_temperature_cell_id=4,
+    ):
+        self.name = name
+        self.service = "com.victronenergy.battery.%s" % name
+        self.voltage = voltage
+        self.current = current
+        self.power = power
+        self.temperature = temperature
+        self.max_cell_voltage = max_cell_voltage
+        self.max_voltage_cell_id = max_voltage_cell_id
+        self.min_cell_voltage = min_cell_voltage
+        self.min_voltage_cell_id = min_voltage_cell_id
+        self.max_cell_temperature = max_cell_temperature
+        self.max_temperature_cell_id = max_temperature_cell_id
+        self.min_cell_temperature = min_cell_temperature
+        self.min_temperature_cell_id = min_temperature_cell_id
+
+    @property
+    def max_voltage_key(self):
+        """The dictionary key the driver builds for this battery's max cell voltage."""
+        return "%s: %s" % (self.name, self.max_voltage_cell_id)
+
+    @property
+    def min_voltage_key(self):
+        return "%s: %s" % (self.name, self.min_voltage_cell_id)
+
+    @property
+    def max_temperature_key(self):
+        return "%s: %s" % (self.name, self.max_temperature_cell_id)
+
+    @property
+    def min_temperature_key(self):
+        return "%s: %s" % (self.name, self.min_temperature_cell_id)
+
+    def values(self):
+        values = {(self.service, path): value for path, value in HEALTHY_BATTERY.items()}
+        values[(self.service, "/CustomName")] = self.name
+        values[(self.service, "/Dc/0/Voltage")] = self.voltage
+        values[(self.service, "/Dc/0/Current")] = self.current
+        values[(self.service, "/Dc/0/Power")] = self.power
+        values[(self.service, "/Dc/0/Temperature")] = self.temperature
+        values[(self.service, "/System/MaxCellVoltage")] = self.max_cell_voltage
+        values[(self.service, "/System/MaxVoltageCellId")] = self.max_voltage_cell_id
+        values[(self.service, "/System/MinCellVoltage")] = self.min_cell_voltage
+        values[(self.service, "/System/MinVoltageCellId")] = self.min_voltage_cell_id
+        values[(self.service, "/System/MaxCellTemperature")] = self.max_cell_temperature
+        values[(self.service, "/System/MaxTemperatureCellId")] = self.max_temperature_cell_id
+        values[(self.service, "/System/MinCellTemperature")] = self.min_cell_temperature
+        values[(self.service, "/System/MinTemperatureCellId")] = self.min_temperature_cell_id
+        for cell in range(1, NR_OF_CELLS + 1):
+            values[(self.service, "/Voltages/Cell%d" % cell)] = 3.3
+        for alarm in ALARM_PATHS:
+            values[(self.service, alarm)] = 0
+        return values
+
+
+class DriverTestCase(unittest.TestCase):
+    """Base class that builds a runnable DbusAggBatService around scripted batteries."""
+
+    def setUp(self):
+        # never touch the filesystem from a unit test
+        patcher = mock.patch.object(driver, "_write_atomic")
+        self.write_atomic = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _patch_settings(self, **overrides):
+        defaults = {
+            "NR_OF_CELLS_PER_BATTERY": NR_OF_CELLS,
+            "CAN_batteries": False,
+            "OWN_SOC": False,
+            "OWN_CHARGE_PARAMETERS": False,
+            "CURRENT_FROM_VICTRON": False,
+            "KEEP_MAX_CVL": False,
+            "SEND_CELL_VOLTAGES": 0,
+            "LOG_PERIOD": 0,
+            "READ_TRIALS": 10,
+            "CHARGE_SAVE_PRECISION": 0.01,
+            "TIME_BEFORE_RESTART": 0,
+        }
+        defaults.update(overrides)
+        for name, value in defaults.items():
+            patcher = mock.patch.object(driver.settings, name, value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def make_service(self, batteries, **settings_overrides):
+        """Build a DbusAggBatService wired to `batteries`, ready for _update()."""
+
+        settings_overrides.setdefault("NR_OF_BATTERIES", len(batteries))
+        self._patch_settings(**settings_overrides)
+
+        values = {}
+        for battery in batteries:
+            values.update(battery.values())
+
+        return new_service(
+            _fn=driver.Functions(),
+            _batteries_dict={battery.name: battery.service for battery in batteries},
+            _dbusMon=FakeDbusMon(values),
+            _dbusservice=RecordingDbusService(),
+            _readTrials=1,
+            _multi=None,
+            _multi_connected=False,
+            _mppts_list=[],
+            _smartShunt_list=[],
+            _num_battery_shunts=0,
+            _ownCharge=90.0,
+            _ownCharge_old=90.0,
+            _timeOld=driver.tt.time(),
+            _balancing=0,
+            _lastBalancing=0,
+            _dynamicCVL=False,
+            _dynCVLactivated=False,
+            _DCfeedActive=False,
+            _fullyDischarged=False,
+            _logLastPrintTimeStamp=int(driver.tt.time()),
+            _reactive_ready=True,
+            _updating=False,
+        )
+
+    def assertNothingWarned(self, service):
+        """Run _update() and assert not a single warning was emitted."""
+        collector = WarningCollector()
+        root = logging.getLogger()
+        root.addHandler(collector)
+        try:
+            result = service._update()
+        finally:
+            root.removeHandler(collector)
+        self.assertEqual([], collector.messages)
+        return result

--- a/tests/test_measurement_graph.py
+++ b/tests/test_measurement_graph.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+
+"""
+Unit tests for the measurement-graph declaration published by the aggregate
+battery service.
+
+Two D-Bus paths are under test:
+
+* ``/Measurement/Kind`` - the constant string ``derived``, telling summing
+  consumers that this service re-publishes values rolled up from other
+  services and must not be counted alongside them.
+* ``/Measurement/TracksServices`` - created empty and filled once the battery
+  search completes, with the discovered battery service names joined by commas
+  in sorted order and without spaces. Consumers parse this string, so the exact
+  format is part of the contract.
+
+The battery search can finish at three different places, and each of them has
+to publish the constituent list, otherwise a system that took that route would
+be left advertising an empty declaration:
+
+* ``_find_batteries``  - current comes from the BMSes, no Victron devices are
+  searched at all.
+* ``_find_multis``     - a MultiPlus/Quattro is used but no MPPTs are configured.
+* ``_find_mppts``      - MPPTs are configured and the expected number was found.
+
+``dbus``, ``vedbus`` and ``gi``/``GLib`` are not importable off the Venus device,
+and ``settings`` exits the interpreter when no ``config.ini`` is present, so
+``driver_harness`` stubs them once for every suite and loads the dash-named
+driver by path. The device search reads a lot of settings and these tests vary
+them, so each test asks the harness for a fresh in-memory settings namespace
+instead of mutating a module-global one.
+
+The service object is never built through ``__init__`` (that one opens a real
+bus). Tests use ``driver_harness.new_service()``, which is ``object.__new__``
+plus only the attributes the methods under test actually read.
+"""
+
+import ast
+import logging
+import unittest
+
+import driver_harness
+
+driver = driver_harness.driver
+
+KIND_PATH = "/Measurement/Kind"
+TRACKS_PATH = "/Measurement/TracksServices"
+
+
+def setUpModule():
+    logging.disable(logging.CRITICAL)
+
+
+def tearDownModule():
+    logging.disable(logging.NOTSET)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+def make_service(batteries=None, bus_names=(), monitor_values=None):
+    """Build a DbusAggBatService without running its D-Bus touching __init__."""
+    return driver_harness.new_service(
+        _dbusservice=driver_harness.RecordingDbusService(),
+        _dbusConn=driver_harness.FakeBus(bus_names),
+        # a path nobody scripted answers None here, the way a real monitor does
+        _dbusMon=driver_harness.FakeDbusMon(monitor_values or {}, default=None),
+        _batteries_dict=dict(batteries or {}),
+        _smartShunt_list=[],
+        _mppts_list=[],
+        _num_battery_shunts=0,
+        _multi=None,
+        _searchTrials=1,
+        _timeOld=0.0,
+        _ownCharge=0.5,
+        _updating=False,
+    )
+
+
+def battery_monitor_values(services_by_name, product_name="SerialBattery(Jkbms)", cells=16):
+    """Monitor answers that make ``_find_batteries`` accept every given service."""
+    values = {}
+    for name, service in services_by_name.items():
+        values[(service, "/ProductName")] = product_name
+        values[(service, "/CustomName")] = name
+        values[(service, "/System/NrOfCellsPerBattery")] = cells
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Source-level assertions about the declaration itself
+# ---------------------------------------------------------------------------
+
+
+def _parse_driver():
+    with open(driver_harness.DRIVER_PATH, "r", encoding="utf-8") as handle:
+        return ast.parse(handle.read(), filename=driver_harness.DRIVER_PATH)
+
+
+def _literal(node):
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError, SyntaxError):
+        return _NON_LITERAL
+
+
+_NON_LITERAL = object()
+
+
+def measurement_add_path_calls():
+    """Every ``add_path`` call for a ``/Measurement/...`` path, as (path, value, kwargs)."""
+    calls = []
+    for node in ast.walk(_parse_driver()):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "add_path" or not node.args:
+            continue
+        path = _literal(node.args[0])
+        if not isinstance(path, str) or not path.startswith("/Measurement/"):
+            continue
+        value = _literal(node.args[1]) if len(node.args) > 1 else _NON_LITERAL
+        kwargs = {keyword.arg: _literal(keyword.value) for keyword in node.keywords}
+        calls.append((path, value, kwargs))
+    return calls
+
+
+def _subscript_key(subscript):
+    node = subscript.slice
+    if isinstance(node, ast.Constant):
+        return node.value
+    # Python 3.8 wraps the subscript key in an ast.Index node
+    inner = getattr(node, "value", None)
+    if isinstance(inner, ast.Constant):
+        return inner.value
+    return None
+
+
+def measurement_subscript_writes():
+    """Every ``self._dbusservice["/Measurement/..."] = ...`` assignment target path."""
+    written = []
+    for node in ast.walk(_parse_driver()):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Subscript):
+                continue
+            key = _subscript_key(target)
+            if isinstance(key, str) and key.startswith("/Measurement/"):
+                written.append(key)
+    return written
+
+
+class MeasurementDeclarationTests(unittest.TestCase):
+    """The two /Measurement paths must be declared once, with the right literals."""
+
+    def test_kind_is_declared_as_the_string_derived(self):
+        kind_calls = [call for call in measurement_add_path_calls() if call[0] == KIND_PATH]
+        self.assertEqual(len(kind_calls), 1, "%s must be declared exactly once" % KIND_PATH)
+        _, value, _ = kind_calls[0]
+        self.assertIsInstance(value, str, "consumers read %s as a string" % KIND_PATH)
+        self.assertEqual(value, "derived")
+
+    def test_tracks_services_is_declared_as_a_writeable_empty_string(self):
+        tracks_calls = [call for call in measurement_add_path_calls() if call[0] == TRACKS_PATH]
+        self.assertEqual(len(tracks_calls), 1, "%s must be declared exactly once" % TRACKS_PATH)
+        _, value, kwargs = tracks_calls[0]
+        self.assertIsInstance(value, str)
+        self.assertEqual(value, "", "%s starts empty and is filled after the search" % TRACKS_PATH)
+        self.assertTrue(kwargs.get("writeable"), "%s is written after creation" % TRACKS_PATH)
+
+    def test_only_kind_and_tracks_services_are_declared(self):
+        declared = sorted(call[0] for call in measurement_add_path_calls())
+        self.assertEqual(declared, [KIND_PATH, TRACKS_PATH])
+
+    def test_the_direct_only_keys_are_not_published(self):
+        """A derived service must not claim to measure a physical device.
+
+        /Measurement/PhysicalDevice, /PeerServices and /LineAuthority are
+        published by services with Kind "direct" — they identify the physical
+        thing being measured, the other services watching it, and which of them
+        is authoritative for the line. None of that is meaningful for a service
+        that computes its values from other services, and a consumer resolving
+        the graph would be misled by it.
+        """
+        declared = {call[0] for call in measurement_add_path_calls()}
+        for path in ("/Measurement/PhysicalDevice", "/Measurement/PeerServices", "/Measurement/LineAuthority"):
+            with self.subTest(path=path):
+                self.assertNotIn(path, declared)
+
+    def test_kind_is_never_reassigned_after_declaration(self):
+        self.assertNotIn(KIND_PATH, measurement_subscript_writes(), "%s is a constant declaration" % KIND_PATH)
+
+    def test_tracks_services_is_the_only_measurement_path_written_at_runtime(self):
+        self.assertEqual(set(measurement_subscript_writes()), {TRACKS_PATH})
+
+
+# ---------------------------------------------------------------------------
+# The three completion paths
+# ---------------------------------------------------------------------------
+
+
+class CompletionPathTestCase(unittest.TestCase):
+    """Shared fixture: fresh settings and a fresh GLib recorder per test."""
+
+    # deliberately unsorted insertion order, and battery names whose sort order
+    # is the reverse of the service-name sort order
+    BATTERIES = {
+        "Zulu": "com.victronenergy.battery.ttyUSB0",
+        "Alpha": "com.victronenergy.battery.ttyUSB2",
+        "Mike": "com.victronenergy.battery.ttyUSB1",
+    }
+    EXPECTED = "com.victronenergy.battery.ttyUSB0,com.victronenergy.battery.ttyUSB1,com.victronenergy.battery.ttyUSB2"
+
+    def setUp(self):
+        self.settings = driver_harness.use_stub_settings(self)
+        self.glib = driver_harness.patch_glib(self)
+
+    def published(self, service):
+        """The value currently on TRACKS_PATH, failing loudly if it was never filled."""
+        self.assertIn(TRACKS_PATH, service._dbusservice.values, "%s was never published" % TRACKS_PATH)
+        value = service._dbusservice.values[TRACKS_PATH]
+        self.assertNotEqual(value, "", "%s was left at its empty declaration value" % TRACKS_PATH)
+        return value
+
+    # -- the three ways the search can finish -------------------------------
+
+    def run_batteries_only_path(self, batteries=None):
+        """Finish in _find_batteries: current comes from the BMSes."""
+        batteries = self.BATTERIES if batteries is None else batteries
+        self.settings.CURRENT_FROM_VICTRON = False
+        self.settings.NR_OF_BATTERIES = len(batteries)
+        service = make_service(
+            bus_names=sorted(batteries.values()),
+            monitor_values=battery_monitor_values(batteries),
+        )
+        self.assertIs(service._find_batteries(), False, "the search must stop once it succeeded")
+        return service
+
+    def run_no_mppt_path(self, batteries=None):
+        """Finish in _find_multis: a Multi is used and no MPPTs are configured."""
+        batteries = self.BATTERIES if batteries is None else batteries
+        self.settings.NR_OF_MPPTS = 0
+        multi = "com.victronenergy.vebus.ttyO1"
+        service = make_service(
+            batteries=batteries,
+            bus_names=[multi],
+            monitor_values={(multi, "/ProductName"): "MultiPlus-II 48/5000"},
+        )
+        self.assertIs(service._find_multis(), False, "the search must stop once it succeeded")
+        return service
+
+    def run_mppt_path(self, batteries=None):
+        """Finish in _find_mppts: the configured number of MPPTs was found."""
+        batteries = self.BATTERIES if batteries is None else batteries
+        mppts = ["com.victronenergy.solarcharger.ttyO2", "com.victronenergy.solarcharger.ttyO3"]
+        self.settings.NR_OF_MPPTS = len(mppts)
+        service = make_service(
+            batteries=batteries,
+            bus_names=mppts,
+            monitor_values={(mppt, "/ProductName"): "SmartSolar MPPT" for mppt in mppts},
+        )
+        self.assertIs(service._find_mppts(), False, "the search must stop once it succeeded")
+        return service
+
+    def completion_paths(self):
+        return (
+            ("batteries only", self.run_batteries_only_path),
+            ("no MPPT", self.run_no_mppt_path),
+            ("MPPT", self.run_mppt_path),
+        )
+
+
+class TracksServicesPublishedOnEveryPathTests(CompletionPathTestCase):
+    """None of the three completion routes may leave the declaration empty."""
+
+    def test_batteries_only_path_publishes_the_constituents(self):
+        service = self.run_batteries_only_path()
+        self.assertEqual(self.published(service), self.EXPECTED)
+
+    def test_no_mppt_path_publishes_the_constituents(self):
+        service = self.run_no_mppt_path()
+        self.assertEqual(self.published(service), self.EXPECTED)
+
+    def test_mppt_path_publishes_the_constituents(self):
+        service = self.run_mppt_path()
+        self.assertEqual(self.published(service), self.EXPECTED)
+
+    def test_every_path_writes_tracks_services_exactly_once(self):
+        for label, run_path in self.completion_paths():
+            with self.subTest(path=label):
+                service = run_path()
+                writes = service._dbusservice.writes_to(TRACKS_PATH)
+                self.assertEqual(len(writes), 1, "%s path wrote %s %d times" % (label, TRACKS_PATH, len(writes)))
+                self.assertEqual(writes[0], self.EXPECTED)
+
+    def test_every_path_agrees_on_the_published_value(self):
+        published = {label: self.published(run_path()) for label, run_path in self.completion_paths()}
+        self.assertEqual(set(published.values()), {self.EXPECTED}, published)
+
+
+class TracksServicesFormatTests(CompletionPathTestCase):
+    """The string is parsed by consumers, so its shape is part of the contract."""
+
+    def test_value_is_comma_separated_without_spaces(self):
+        for label, run_path in self.completion_paths():
+            with self.subTest(path=label):
+                value = self.published(run_path())
+                self.assertNotIn(" ", value, "consumers split on ',' only")
+                self.assertEqual(value.split(","), sorted(self.BATTERIES.values()))
+
+    def test_value_is_sorted_by_service_name_not_by_battery_name(self):
+        # battery names sort Alpha < Mike < Zulu, which is the reverse of the
+        # service-name order; sorting the wrong side of the dict would show up here
+        value = self.published(self.run_no_mppt_path())
+        self.assertEqual(value, self.EXPECTED)
+        self.assertNotEqual(value, ",".join(self.BATTERIES[name] for name in sorted(self.BATTERIES)))
+
+    def test_single_battery_value_has_no_separator(self):
+        one = {"OnlyBattery": "com.victronenergy.battery.ttyUSB9"}
+        for label, run_path in self.completion_paths():
+            with self.subTest(path=label):
+                value = self.published(run_path(batteries=one))
+                self.assertEqual(value, "com.victronenergy.battery.ttyUSB9")
+
+    def test_value_is_a_plain_string(self):
+        value = self.published(self.run_mppt_path())
+        self.assertIsInstance(value, str)
+
+
+class TracksServicesFollowsDiscoveryTests(CompletionPathTestCase):
+    """The names come from the discovered batteries dict, never from a fixed list."""
+
+    OTHER_BATTERIES = {
+        "Delta": "com.victronenergy.battery.socketcan_can0",
+        "Charlie": "com.victronenergy.battery.socketcan_can1",
+    }
+    OTHER_EXPECTED = "com.victronenergy.battery.socketcan_can0,com.victronenergy.battery.socketcan_can1"
+
+    def test_a_different_batteries_dict_yields_a_different_value(self):
+        for label, run_path in self.completion_paths():
+            with self.subTest(path=label):
+                value = self.published(run_path(batteries=self.OTHER_BATTERIES))
+                self.assertEqual(value, self.OTHER_EXPECTED)
+                self.assertNotEqual(value, self.EXPECTED)
+
+    def test_batteries_only_path_publishes_what_the_bus_scan_discovered(self):
+        service = self.run_batteries_only_path()
+        self.assertEqual(
+            self.published(service),
+            ",".join(sorted(service._batteries_dict.values())),
+        )
+        self.assertEqual(sorted(service._batteries_dict.values()), sorted(self.BATTERIES.values()))
+
+    def test_services_of_non_battery_devices_are_not_tracked(self):
+        self.settings.CURRENT_FROM_VICTRON = False
+        self.settings.NR_OF_BATTERIES = len(self.BATTERIES)
+        monitor_values = battery_monitor_values(self.BATTERIES)
+        decoy = "com.victronenergy.battery.ttyUSB7"
+        monitor_values[(decoy, "/ProductName")] = "Some Other BMS"
+        service = make_service(
+            bus_names=sorted(list(self.BATTERIES.values()) + [decoy, "com.victronenergy.system"]),
+            monitor_values=monitor_values,
+        )
+        self.assertIs(service._find_batteries(), False)
+        self.assertEqual(self.published(service), self.EXPECTED)
+        self.assertNotIn(decoy, self.published(service))
+
+
+class TracksServicesNotPublishedBeforeCompletionTests(CompletionPathTestCase):
+    """An unfinished search must not publish a partial constituent list."""
+
+    def test_incomplete_battery_search_publishes_nothing(self):
+        self.settings.CURRENT_FROM_VICTRON = False
+        self.settings.NR_OF_BATTERIES = len(self.BATTERIES) + 1
+        service = make_service(
+            bus_names=sorted(self.BATTERIES.values()),
+            monitor_values=battery_monitor_values(self.BATTERIES),
+        )
+        self.assertIs(service._find_batteries(), True, "the search must retry")
+        self.assertEqual(service._dbusservice.writes_to(TRACKS_PATH), [])
+
+    def test_multi_search_defers_publishing_to_the_mppt_search(self):
+        self.settings.NR_OF_MPPTS = 2
+        multi = "com.victronenergy.vebus.ttyO1"
+        service = make_service(
+            batteries=self.BATTERIES,
+            bus_names=[multi],
+            monitor_values={(multi, "/ProductName"): "MultiPlus-II 48/5000"},
+        )
+        self.assertIs(service._find_multis(), False)
+        self.assertEqual(service._dbusservice.writes_to(TRACKS_PATH), [])
+
+    def test_incomplete_mppt_search_publishes_nothing(self):
+        self.settings.NR_OF_MPPTS = 2
+        found = ["com.victronenergy.solarcharger.ttyO2"]
+        service = make_service(
+            batteries=self.BATTERIES,
+            bus_names=found,
+            monitor_values={(found[0], "/ProductName"): "SmartSolar MPPT"},
+        )
+        self.assertIs(service._find_mppts(), True, "the search must retry")
+        self.assertEqual(service._dbusservice.writes_to(TRACKS_PATH), [])
+
+    def test_battery_search_delegates_to_multi_search_without_publishing(self):
+        self.settings.CURRENT_FROM_VICTRON = True
+        self.settings.NR_OF_BATTERIES = len(self.BATTERIES)
+        service = make_service(
+            bus_names=sorted(self.BATTERIES.values()),
+            monitor_values=battery_monitor_values(self.BATTERIES),
+        )
+        self.assertIs(service._find_batteries(), False)
+        self.assertEqual(service._dbusservice.writes_to(TRACKS_PATH), [])
+        self.assertIn(service._find_multis, self.glib.scheduled_callbacks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Draft while it soaks on our production system.

## Problem

Anything summing battery services across the bus counts this one *and* the batteries it aggregates, so the same energy lands twice. There is no way to tell from the published values that this service is a roll-up of two others rather than a third battery.

The usual workaround is matching on the service name. That breaks when a driver is renamed, and a user can set any `CustomName` they like.

This is not hypothetical: on the system this was written for, a battery measured by both its BMS and a SmartShunt produced a DC load reading of about 20.5 A against a true 13.5 A, which fed into DVCC compensation and set the bank oscillating.

## Change

Nine lines. The service declares what it is:

```
/Measurement/Kind           = derived
/Measurement/TracksServices = com.victronenergy.battery.ble_xxx,com.victronenergy.battery.ble_yyy
```

Both are declared at registration. `TracksServices` is written once the battery search completes — at each of the three points where the search can complete — sorted and comma separated without spaces, naming the services actually discovered rather than anything configured.

A consumer can then exclude this service structurally, and knows exactly which services it would otherwise double count.

## The vocabulary

Five string paths, shared with the battery drivers, which publish the `direct` half:

| Path | Value | Published by | Meaning |
| --- | --- | --- | --- |
| `/Measurement/Kind` | `direct` or `derived` | every participant | `direct`: I measure a physical device. `derived`: I compute from other services |
| `/Measurement/PhysicalDevice` | opaque string | `direct` only | grouping key — two services with the same value measure the same physical thing |
| `/Measurement/PeerServices` | comma-separated service names | `direct` only | other services observing my physical device |
| `/Measurement/LineAuthority` | single service name | `direct` only | which service is the truth for line voltage and current |
| `/Measurement/TracksServices` | comma-separated service names | `derived` only | what I aggregate |

This driver publishes two of the five. The three `direct` keys identify a physical device, and this service observes none — a test names them as forbidden, with the reason.

The full contract is in [`docs/measurement-topology.md`](docs/measurement-topology.md): value formats, how a consumer resolves the graph, and what an absent path means. The same document ships with the battery drivers, with the schema sections identical in both copies.

**This is not a Victron standard**, and I would rather say that plainly than have you discover it. It is a convention two drivers implement so that a consumer can resolve the topology without name matching. Nothing consumes it today; it costs nine lines and two paths, and it is inert for anyone who ignores it.

## Tests

22 stdlib-`unittest` tests, run with `python3 -m unittest discover -s tests` — no D-Bus, no Venus OS, no new dependencies. They cover: `Kind` declared exactly once as the literal `derived` and never reassigned; `TracksServices` declared writeable and empty; all three search-completion routes exercised for real against a recording fake service; written exactly once per route; the sorted, comma separated, space free format that consumers parse; the value following the discovered set rather than a fixed list; the direct-only keys absent; and the negative cases — incomplete searches and `CURRENT_FROM_VICTRON = True` — publishing nothing.

Verified live on a Cerbo GX: `/Measurement/Kind` reads `derived` and `/Measurement/TracksServices` lists both BLE battery services.

## Notes

- The branch is based directly on `main` and is independent of my other open PRs.
- The lint check reports the failure already present on `main`; #164 fixes it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)