### PR TITLE
fix: a battery that omits its charge limits stops the update loop for good

### DIFF
--- a/dbus-aggregate-batteries.py
+++ b/dbus-aggregate-batteries.py
@@ -1042,12 +1042,29 @@ class DbusAggBatService(object):
                 # Aggregate charge/discharge parameters
                 else:
                     step = "Read charge parameters"
+                    # A battery that is on the bus but not yet serving data answers None
+                    # here. Appending that None makes Functions._min() return None for the
+                    # whole bank, which is published as an invalid CVL and then raises in
+                    # the periodic logging below, outside any try - and an exception leaving
+                    # _update() makes GLib drop the timeout source, so the driver stops
+                    # updating for good while its service stays on the bus. Raise instead,
+                    # so the read trial handling above retries and restarts as designed.
+                    max_charge_current = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Info/MaxChargeCurrent")
+                    max_discharge_current = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Info/MaxDischargeCurrent")
+                    max_charge_voltage = self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Info/MaxChargeVoltage")
+
+                    if max_charge_current is None or max_discharge_current is None or max_charge_voltage is None:
+                        raise ValueError(
+                            "Missing charge parameter while reading battery %s: MaxChargeVoltage=%s, MaxChargeCurrent=%s, MaxDischargeCurrent=%s"
+                            % (i, max_charge_voltage, max_charge_current, max_discharge_current)
+                        )
+
                     # list of max. charge currents to find minimum
-                    MaxChargeCurrent_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Info/MaxChargeCurrent"))
+                    MaxChargeCurrent_list.append(max_charge_current)
                     # list of max. discharge currents  to find minimum
-                    MaxDischargeCurrent_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Info/MaxDischargeCurrent"))
+                    MaxDischargeCurrent_list.append(max_discharge_current)
                     # list of max. charge voltages  to find minimum
-                    MaxChargeVoltage_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Info/MaxChargeVoltage"))
+                    MaxChargeVoltage_list.append(max_charge_voltage)
                     # list of charge modes of batteries (Bulk, Absorption, Float, Keep always max voltage)
                     ChargeMode_list.append(self._dbusMon.dbusmon.get_value(self._batteries_dict[i], "/Info/ChargeMode"))
 


### PR DESCRIPTION
Eleven lines of code plus comments. This is the small, self-contained part of #166, which I have closed — you were right about the rest.

## The chain

A constituent that is on the bus but not yet serving data answers `None` for `/Info/MaxChargeVoltage`. In the default configuration (`OWN_CHARGE_PARAMETERS = False`) what follows is silent and permanent:

1. `Functions._min([13.8, None])` catches the `TypeError` internally and returns `None`, so the bank limit becomes `None`.
2. That `None` is published as the aggregate CVL. D-Bus renders it *invalid* — and systemcalc stops treating this service as the BMS, because `is_bms` is literally `get_value(service, "/Info/MaxChargeVoltage") is not None`.
3. The periodic logging then formats it: `"|- CVL: %.1fV..." % (MaxChargeVoltage, ...)` raises `TypeError: must be real number, not NoneType`. That line sits *after* the publish block and *outside* the read-trial `try/except`.
4. The exception leaves `_update()`, which is a GLib timeout callback, so **GLib drops the source**. The driver never updates again, while its service stays on the bus publishing the values it last wrote.

**`READ_TRIALS` cannot help here**, which is why I am sending this separately from the discussion on #166: no exception ever reaches the trial counter, so nothing is counted, and the process never exits. The read-trial handler is at line 1078; the raise is at line 1526.

## Reproducing the GLib half

On a Cerbo GX, with its own Python and GLib:

```python
from gi.repository import GLib
calls = {"n": 0}

def cb():
    calls["n"] += 1
    print("callback run #%d" % calls["n"])
    if calls["n"] == 2:
        "%.1f" % None      # exactly what the periodic log line does
    return True            # the driver returns True to stay scheduled

GLib.timeout_add_seconds(1, cb)
GLib.MainLoop().run()
```

```
callback run #1
callback run #2
TypeError: must be real number, not NoneType
-> the callback is never run again
```

`exec 2>&1` in the run script means the traceback does reach the log, so it is not invisible — but it reads as one transient error followed by silence, and the aggregate simply stops updating until someone restarts it.

## The fix

Read the three limits into locals and raise if any is `None`, so this lands on the read-trial path you already have: a battery that is not ready is retried, and if it stays that way the driver exits and restarts, as you intend.

I deliberately did **not** change `Functions._min` to stop swallowing the `TypeError`, although that is the root cause. `_max`/`_min` are used 21 times, mostly for alarms, and alarms legitimately hold `None` when a BMS does not publish a path — making them raise would put those systems into a restart loop.

## Two things you should weigh

- **This is insurance, not a live fix for me.** The constituent driver that triggered it on my system has since guarded its own write, so the chain no longer starts here. I am sending it because the hole is in the aggregate and any constituent can fall into it.
- **It changes behaviour for one group.** A BMS driver that *never* publishes those paths currently gets an invalid CVL published and, with `LOG_PERIOD = 0`, keeps running that way indefinitely. After this change it gets a restart loop instead. That is louder — though such a system is not charging anyway, since systemcalc has already stopped treating it as the BMS — but it is a real change and you may want it noted in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)