### PR TITLE
service/run: exec python3 instead of trap/wait shim

### DIFF
--- a/service/run
+++ b/service/run
@@ -1,20 +1,8 @@
 #!/bin/sh
 
-# Forward signals to the child process
-trap 'kill -TERM $PID' TERM INT
-
-# Start the main process
+# Replace the shell with the driver so supervise's TERM/INT reaches python
+# directly. The previous trap/wait shim forwarded a single TERM and then
+# exited the shell, which let supervise respawn the service while the old
+# python could still be alive holding the dbus name (restart loop).
 exec 2>&1
-exec python3 /data/apps/dbus-aggregate-batteries/dbus-aggregate-batteries.py &
-
-# Capture the PID of the child process
-PID=$!
-
-# Wait for the child process to exit
-wait $PID
-
-# Capture the exit status
-EXIT_STATUS=$?
-
-# Exit with the same status
-exit $EXIT_STATUS
+exec python3 /data/apps/dbus-aggregate-batteries/dbus-aggregate-batteries.py


### PR DESCRIPTION
## Summary

`service/run` currently starts the driver in the background, traps TERM/INT, and `wait`s on the child PID. When supervise sends TERM, the trap forwards one TERM to python, but the same signal interrupts `wait`, so the shell falls through and exits whether or not python has actually terminated. supervise sees the run script gone, frees the slot, and respawns the service.

If the python process survives that single TERM for any reason (a non-daemon thread blocking interpreter shutdown, a slow teardown), it is orphaned while still owning `com.victronenergy.battery.aggregate`. The respawned instance then fails setup because the name is taken, dies, and the service enters a restart loop.

This PR replaces the shim with `exec python3 ...`, so the shell is replaced by the driver, supervise's TERM reaches python directly, and the slot is only freed once python itself exits. The `exec 2>&1` preamble is kept so logging still flows to multilog.

## Background

The same shim pattern in a sibling Venus OS driver produced exactly this restart loop on a production Cerbo on 2026-09-02 (seven respawns in about ten minutes, verified by process parentage and dbus name ownership). dbus-aggregate-batteries has not been observed looping, since its only extra thread returns immediately, but the run script has the same structural flaw and the fix is the same one-line change.

## Test plan

- [x] `sh -n service/run` passes
- [x] Existing `enable.sh` only `chmod`s the run file and does not regenerate it, so the change persists across reboots once deployed
- [ ] Deploy to a Cerbo, `svc -t /service/dbus-aggregate-batteries`, confirm the python process is a direct child of supervise and the service restarts exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)